### PR TITLE
Update location.yaml

### DIFF
--- a/code/API_definitions/location.yaml
+++ b/code/API_definitions/location.yaml
@@ -97,14 +97,14 @@ components:
           $ref: '#/components/schemas/Longitude'
         accuracy:
           $ref: '#/components/schemas/Accuracy'
-        maxLocationAge:
-          $ref: '#/components/schemas/MaxLocationAge'
+        maxAge:
+          $ref: '#/components/schemas/MaxAge'
       required:
         - ueId
         - latitude
         - longitude
         - accuracy
-        - maxLocationAge 
+        - maxAge 
     VerifyLocationResponse:
       type: object
       required:
@@ -184,7 +184,7 @@ components:
       minimum: 2
       maximum: 200
       example: 50
-    MaxLocationAge:
+    MaxAge:
       description: Max location aging validity required by the application in Minute, Default =0 for realtime location
       type: number
       minimum: 0

--- a/code/API_definitions/location.yaml
+++ b/code/API_definitions/location.yaml
@@ -8,7 +8,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.1.0
+  version: 0.2.0
 externalDocs:
   description: Product documentation at Camara
   url: https://github.com/camaraproject/

--- a/code/API_definitions/location.yaml
+++ b/code/API_definitions/location.yaml
@@ -97,11 +97,14 @@ components:
           $ref: '#/components/schemas/Longitude'
         accuracy:
           $ref: '#/components/schemas/Accuracy'
+        maxLocationAge:
+          $ref: '#/components/schemas/MaxLocationAge'
       required:
         - ueId
         - latitude
         - longitude
         - accuracy
+        - maxLocationAge 
     VerifyLocationResponse:
       type: object
       required:
@@ -181,6 +184,12 @@ components:
       minimum: 2
       maximum: 200
       example: 50
+    MaxLocationAge:
+      description: Max location aging validity required by the application in Minute
+      type: number
+      minimum: 1
+      maximum: 1440
+      example: 30
     VerificationResult:
       description: Result of a verification request, true on match
       type: boolean

--- a/code/API_definitions/location.yaml
+++ b/code/API_definitions/location.yaml
@@ -185,9 +185,9 @@ components:
       maximum: 200
       example: 50
     MaxLocationAge:
-      description: Max location aging validity required by the application in Minute
+      description: Max location aging validity required by the application in Minute, Default =0 for realtime location
       type: number
-      minimum: 1
+      minimum: 0
       maximum: 1440
       example: 30
     VerificationResult:


### PR DESCRIPTION
Included request parameter “MaxLocationAge’ to give the developer option to mention the maximum aging of the location info, accepted by the application. 

If the developer wants only real-time or near real-time information, we as operators then can avoid validating against stale location info resulted from network reasons such as device switched-off, not in servicing area, device issues etc.