### PR TITLE
Swagger definition for Get device location

### DIFF
--- a/code/API_definitions/Get DeviceLocation.yaml
+++ b/code/API_definitions/Get DeviceLocation.yaml
@@ -100,7 +100,8 @@ components:
           $ref: '#/components/schemas/Device'
         maxAge:
           type: integer
-          description: Maximum age of the location information which is accepted for the verification (in seconds)
+          description: Maximum age of the location information which is accepted for the location retrieval (in seconds)
+
           minimum: 60
       required:
         - device

--- a/code/API_definitions/Get DeviceLocation.yaml
+++ b/code/API_definitions/Get DeviceLocation.yaml
@@ -26,7 +26,7 @@ servers:
         default: location/v0
         description: Base path for the device location API
 paths:
-  /retrieve-location:
+  /retrieve:
     post:
       tags:
         - Location retrieval

--- a/code/API_definitions/Get DeviceLocation.yaml
+++ b/code/API_definitions/Get DeviceLocation.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: Get Device location API
+  title: Retrieve Device location API
   description: Service Enabling Network Function API for location retrieval from a device identifier.
   termsOfService: http://swagger.io/terms/
   contact:
@@ -28,59 +28,18 @@ servers:
         default: location/v0
         description: Base path for the device location API
 paths:
-  /locations:
-    get:
+  /location:
+    post:
       tags:
         - Location retrieval
-      summary: 'Retrieve location for a user equipment'
+      summary: 'Execute location retrieval for a user equipment'
       operationId: retrieveLocation
-      description: Retrieve location for an user equipement from an identifier like phone number, IP address (and port) or external identifier provided by the network operator.
-      parameters:
-          - description: Subscriber number in E.164 format (starting with country code). Optionally prefixed with '+'.
-            name: phoneNumber
-            in : query
-            schema: 
-              type: string
-              pattern: '^\+?[0-9]{5,15}$'
-          - description: Identifier assigned by the mobile network operator (MNO) for the device 
-            name: networkAccessIdentifier
-            in: query
+      requestBody:
+        content:
+          application/json:
             schema:
-              type: string
-          - description:  |
-              IPv6 address, following IETF 5952 format, may be specified in form <address/mask> as:
-                - address - The /128 subnet is optional for single addresses:
-                  - 2001:db8:85a3:8d3:1319:8a2e:370:7344
-                  - 2001:db8:85a3:8d3:1319:8a2e:370:7344/128
-                - address/mask - an IP v6 number with a mask:
-                  - 2001:db8:85a3:8d3::0/64
-                  - 2001:db8:85a3:8d3::/64
-            name: ipv6Address
-            in : query
-            schema:
-              type: string
-              pattern: 
-                -'^((:|(0?|([1-9a-f][0-9a-f]{0,3}))):)((0?|([1-9a-f][0-9a-f]{0,3})):){0,6}(:|(0?|([1-9a-f][0-9a-f]{0,3})))(\/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))?$'
-                -'^((([^:]+:){7}([^:]+))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?))(\/.+)?$'
-          - description: |
-              IPv4 address may be specified in form <address/mask> as:
-              - address - an IPv4 number in dotted-quad form 1.2.3.4. Only this exact IP number will match the flow control rule.
-              - address/mask - an IP number as above with a mask width of the form 1.2.3.4/24.
-              In this case, all IP numbers from 1.2.3.0 to 1.2.3.255 will match. The bit width MUST be valid for the IP version.
-            name: Ipv4Address
-            in : query
-            schema:
-              type: string
-              pattern: 
-                -'^((:|(0?|([1-9a-f][0-9a-f]{0,3}))):)((0?|([1-9a-f][0-9a-f]{0,3})):){0,6}(:|(0?|([1-9a-f][0-9a-f]{0,3})))(\/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))?$'
-                -'^((([^:]+:){7}([^:]+))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?))(\/.+)?$'
-          - description: User equipment port. Device port may be required along with IP address to identify the target device
-            name: port
-            in : query
-            schema:
-              type: integer
-              minimum: 0
-              maximum: 65535
+              $ref: '#/components/schemas/RetrievalLocationRequest'
+        required: true
       responses:
         '200':
           description: Location retrieval result
@@ -96,7 +55,6 @@ paths:
                     latitude: 50.735851
                     longitude: 7.10066
                     accuracy: 2
-
         '400':
           $ref: '#/components/responses/Generic400'
         '401':
@@ -134,6 +92,67 @@ components:
           scopes:
             device-location-provide: Provide device location
   schemas:
+    RetrievalLocationRequest:
+      type: object
+      properties:
+        ueId:
+          $ref: '#/components/schemas/UeId'
+        uePort:
+          $ref: '#/components/schemas/Port'
+      required:
+        - ueId
+    UeId:
+      description: User equipment identifier
+      type: object
+      properties:
+        externalId:
+          $ref: '#/components/schemas/ExternalId'
+        msisdn:
+          $ref: '#/components/schemas/MSISDN'
+        ipv4Addr:
+          $ref: '#/components/schemas/Ipv4Addr'
+        ipv6Addr:
+          $ref: '#/components/schemas/Ipv6Addr'
+      minProperties: 1
+    ExternalId:
+      type: string
+      example: '123456789@domain.com'
+    MSISDN:
+      type: string
+      pattern: '^\+?[0-9]{5,15}$'
+      example: '123456789'
+      description: Subscriber number in E.164 format (starting with country code). Optionally prefixed with '+'.
+    Ipv4Addr:
+      type: string
+      format: ipv4
+      pattern: '^([01]?\d\d?|2[0-4]\d|25[0-5])(?:\.(?:[01]?\d\d?|2[0-4]\d|25[0-5])){3}(\/([0-9]|[1-2][0-9]|3[0-2]))?$'
+      example: '192.168.0.1/24'
+      description: |
+        IPv4 address may be specified in form <address/mask> as:
+          - address - an IPv4 number in dotted-quad form 1.2.3.4. Only this exact IP number will match the flow control rule.
+          - address/mask - an IP number as above with a mask width of the form 1.2.3.4/24.
+            In this case, all IP numbers from 1.2.3.0 to 1.2.3.255 will match. The bit width MUST be valid for the IP version.
+    Ipv6Addr:
+      type: string
+      format: ipv6
+      allOf:
+        - pattern: '^((:|(0?|([1-9a-f][0-9a-f]{0,3}))):)((0?|([1-9a-f][0-9a-f]{0,3})):){0,6}(:|(0?|([1-9a-f][0-9a-f]{0,3})))(\/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))?$'
+        - pattern: '^((([^:]+:){7}([^:]+))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?))(\/.+)?$'
+      example: '2001:db8:85a3:8d3:1319:8a2e:370:7344'
+      description: |
+        IPv6 address, following IETF 5952 format, may be specified in form <address/mask> as:
+          - address - The /128 subnet is optional for single addresses:
+            - 2001:db8:85a3:8d3:1319:8a2e:370:7344
+            - 2001:db8:85a3:8d3:1319:8a2e:370:7344/128
+          - address/mask - an IP v6 number with a mask:
+            - 2001:db8:85a3:8d3::0/64
+            - 2001:db8:85a3:8d3::/64
+    Port:
+      type: integer
+      minimum: 0
+      maximum: 65535
+      description: User equipment port. Device port may be required along with IP address to identify the target device
+      example: 5060
     RetrievalLocationResponse:
       type: object
       required:

--- a/code/API_definitions/Get DeviceLocation.yaml
+++ b/code/API_definitions/Get DeviceLocation.yaml
@@ -291,7 +291,7 @@ components:
                 message: 'Invalid input'
             MaxAgeIssue:
               value:
-                tatus: 400
+                status: 400
                 code: LOCATION_RETRIEVAL.MAXAGE_INVALID_ARGUMENT
                 message: 'maxAge threshold cannot be satisfied'
     Generic401:

--- a/code/API_definitions/Get DeviceLocation.yaml
+++ b/code/API_definitions/Get DeviceLocation.yaml
@@ -94,7 +94,7 @@ components:
           authorizationUrl: https://auth.example.com/authorize
           tokenUrl: https://auth.example.com/token
           scopes:
-            device-location-provide: Provide device location
+            location-retrieval-read: Provide device location
   schemas:
     RetrievalLocationRequest:
       type: object

--- a/code/API_definitions/Get DeviceLocation.yaml
+++ b/code/API_definitions/Get DeviceLocation.yaml
@@ -17,7 +17,7 @@ security:
 #  - BasicAuth: []
 #  - apiKey: []
   - three_legged:
-    - device-location-provide
+    - location-retrieval-read
 servers:
   - url: '{apiRoot}/{basePath}'
     variables:
@@ -46,18 +46,21 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RetrievalLocationResponse'
+                $ref: '#/components/schemas/Location'
               examples: 
                 'success':
                   summary: successful location
                   description: The network provides device location
                   value:
-                    latitude: 50.735851
-                    longitude: 7.10066
-                    accuracy: 2000
                     lastLocationTime: 2023-01-17T13:18:23.682Z
+                    area:
+                      areaType: Circle
+                      center:
+                        latitude: 50.735851
+                        longitude: 7.10066
+                      radius: 2000
         '400':
-          $ref: '#/components/responses/Generic400'
+          $ref: '#/components/responses/RetrieveLocationBadRequest400'
         '401':
           $ref: '#/components/responses/Generic401'
         '403':
@@ -101,7 +104,6 @@ components:
         maxAge:
           type: integer
           description: Maximum age of the location information which is accepted for the location retrieval (in seconds)
-
           minimum: 60
       required:
         - device
@@ -183,36 +185,79 @@ components:
       maximum: 65535
       description: User equipment port. Device port may be required along with IP address to identify the target device
       example: 5060
-    RetrievalLocationResponse:
-      type: object
-      required:
-        - latitude
-        - longitude
-        - accuracy
-        - lastLocationTime
-      properties:
-        latitude:
-          description: Latitude component of a location
-          type: number
-          format: double
-          minimum: -90
-          maximum: 90
-          example: 50.735851      
-        longitude:
-          description: Longitude component of location
-          type: number
-          format: double
-          minimum: -180
-          maximum: 180
-          example: 7.10066     
-        accuracy:
-          type: number
-          description: Provided accuracy for the location, in meters, from the point defined by latitude/longitude
 
+    Location:
+      type: object
+      description: Device location
+      required:
+        - lastLocationTime
+        - area
+      properties:
         lastLocationTime: 
           description: Last date and time when the device was localized (using ISO 8601 with timezone)
           type: string
           format: datetime
+        area:
+          $ref: '#/components/schemas/Area'
+        
+    Area:
+      type: object
+      required:
+        - areaType
+      properties:
+        areaType:
+          description: type of the area (like Circle)
+          type: string
+      discriminator: 
+          propertyName: areaType
+          mapping: 
+            Circle:  "#/components/schemas/Circle"
+
+    Circle:
+      description: Circular area
+      allOf: 
+        - $ref: "#/components/schemas/Area"
+        - type: object
+          required:
+            - center
+            - radius
+          properties:
+            center: 
+              $ref: "#/components/schemas/Point"
+            radius:
+              type: number
+              description: Distance from the center in meters
+              minimum: 1
+        
+    Point:
+      type: object
+      description: Coordinates (latitude, longitude) defining a location in a map
+      required: 
+        - latitude
+        - longitude
+      properties: 
+        latitude:
+          $ref: "#/components/schemas/Latitude"
+        longitude:
+          $ref: "#/components/schemas/Longitude"
+      example: 
+        latitude: 50.735851
+        longitude: 7.10066
+
+    Latitude:
+      description: Latitude component of a location
+      type: number
+      format: double
+      minimum: -90
+      maximum: 90
+  
+    Longitude:
+      description: Longitude component of location
+      type: number
+      format: double
+      minimum: -180
+      maximum: 180
+
     ErrorInfo:
       type: object
       required:
@@ -230,16 +275,25 @@ components:
           type: string
           description: Detailed error description
   responses:
-    Generic400:
-      description: Invalid input
+    RetrieveLocationBadRequest400:
+      description: |-
+        Problem with the client request. In addition to regular scenario of `INVALID_ARGUMENT`, another scenarios may exist:
+          - maxAge threshold cannot be satisfied
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorInfo'
-          example:
-            status: 400
-            code: INVALID_ARGUMENT
-            message: 'Invalid input'
+          examples:
+            InvalidArgument:
+              value:
+                status: 400
+                code: INVALID_ARGUMENT
+                message: 'Invalid input'
+            MaxAgeIssue:
+              value:
+                tatus: 400
+                code: LOCATION_RETRIEVAL.MAXAGE_INVALID_ARGUMENT
+                message: 'maxAge threshold cannot be satisfied'
     Generic401:
       description: Unauthorized
       content:

--- a/code/API_definitions/Get DeviceLocation.yaml
+++ b/code/API_definitions/Get DeviceLocation.yaml
@@ -23,8 +23,8 @@ servers:
         default: http://localhost:9091
         description: API root
       basePath:
-        default: location/v0
-        description: Base path for the device location API
+        default: location-retrieval/v0
+        description: Base path for the device location retrieval API
 paths:
   /retrieve:
     post:

--- a/code/API_definitions/Get DeviceLocation.yaml
+++ b/code/API_definitions/Get DeviceLocation.yaml
@@ -14,8 +14,8 @@ externalDocs:
   url: https://github.com/camaraproject/
 security:
   - oAuth2ClientCredentials: []
-  - three_legged:
-    - location-retrieval-read
+  - oAuth2AuthorizationCode:
+    - location-retrieval:read
 servers:
   - url: '{apiRoot}/{basePath}'
     variables:
@@ -85,14 +85,14 @@ components:
 #      description: API key to authorize requests
 #      name: apikey
 #      in: query
-    three_legged:
+    oAuth2AuthorizationCode:
       type: oauth2
       flows:
         authorizationCode:
           authorizationUrl: https://auth.example.com/authorize
           tokenUrl: https://auth.example.com/token
           scopes:
-            location-retrieval-read: Provide device location
+            location-retrieval:read: Provide device location
   schemas:
     RetrievalLocationRequest:
       type: object

--- a/code/API_definitions/Get DeviceLocation.yaml
+++ b/code/API_definitions/Get DeviceLocation.yaml
@@ -54,7 +54,8 @@ paths:
                   value:
                     latitude: 50.735851
                     longitude: 7.10066
-                    accuracy: 2
+                    accuracy: 2000
+                    lastLocationTime: 2023-01-17T13:18:23.682Z
         '400':
           $ref: '#/components/responses/Generic400'
         '401':
@@ -97,6 +98,10 @@ components:
       properties:
         device:
           $ref: '#/components/schemas/Device'
+        maxAge:
+          type: integer
+          description: Maximum age of the location information which is accepted for the verification (in seconds)
+          minimum: 60
       required:
         - device
 
@@ -183,6 +188,7 @@ components:
         - latitude
         - longitude
         - accuracy
+        - lastLocationTime
       properties:
         latitude:
           description: Latitude component of a location
@@ -200,7 +206,11 @@ components:
           example: 7.10066     
         accuracy:
           type: number
-          description: Expected accuracy for the location in km, from the point defined by latitude/longitude
+          description: Expected accuracy for the location in meters, from the point defined by latitude/longitude
+        lastLocationTime: 
+          description: last date and time when the device was localized (using ISO 8601 with timezone)
+          type: string
+          format: datetime
     ErrorInfo:
       type: object
       required:

--- a/code/API_definitions/Get DeviceLocation.yaml
+++ b/code/API_definitions/Get DeviceLocation.yaml
@@ -158,12 +158,6 @@ components:
         accuracy:
           type: number
           description: Expected accuracy for the location in km, from the point defined by latitude/longitude
-    Port:
-      type: integer
-      minimum: 0
-      maximum: 65535
-      description: User equipment port. Device port may be required along with IP address to identify the target device
-      example: 5060
     ErrorInfo:
       type: object
       required:

--- a/code/API_definitions/Get DeviceLocation.yaml
+++ b/code/API_definitions/Get DeviceLocation.yaml
@@ -95,50 +95,81 @@ components:
     RetrievalLocationRequest:
       type: object
       properties:
-        ueId:
-          $ref: '#/components/schemas/UeId'
-        uePort:
+        device:
+          $ref: '#/components/schemas/Device'
+        devicePort:
           $ref: '#/components/schemas/Port'
       required:
-        - ueId
-    UeId:
-      description: User equipment identifier
+        - device
+
+    Device:
       type: object
-      properties:
-        externalId:
-          $ref: '#/components/schemas/ExternalId'
-        msisdn:
-          $ref: '#/components/schemas/MSISDN'
-        ipv4Addr:
-          $ref: '#/components/schemas/Ipv4Addr'
-        ipv6Addr:
-          $ref: '#/components/schemas/Ipv6Addr'
       minProperties: 1
-    ExternalId:
-      type: string
-      example: '123456789@domain.com'
-    MSISDN:
+      properties:
+        phoneNumber:
+          $ref: "#/components/schemas/PhoneNumber"
+        networkAccessIdentifier:
+          $ref: "#/components/schemas/NetworkAccessIdentifier"
+        ipv4Address:
+          $ref: "#/components/schemas/DeviceIpv4Addr"
+        ipv6Address:
+          $ref: "#/components/schemas/Ipv6Address"
+      description: One or more parameters allocated to the device that allow it to be identified
+
+    PhoneNumber:
       type: string
       pattern: '^\+?[0-9]{5,15}$'
-      example: '123456789'
-      description: Subscriber number in E.164 format (starting with country code). Optionally prefixed with '+'.
-    Ipv4Addr:
+      example: "123456789"
+      description: Subscriber number (MSISDN) in E.164 format, starting with country code and optionally prefixed with '+'.
+
+    DeviceIpv4Addr:
+      type: object
+      properties:
+        publicAddress:
+          $ref: "#/components/schemas/SingleIpv4Addr"
+        privateAddress:
+          $ref: "#/components/schemas/SingleIpv4Addr"
+        publicPort:
+          $ref: "#/components/schemas/Port"
+      anyOf:
+        - required: [publicAddress, privateAddress]
+        - required: [publicAddress, publicPort]
+      example:
+            {
+              "publicAddress": "84.125.93.10",
+              "publicPort" : 59765
+            }
+      description: |
+        The device should be identified by either the public (observed) IP address and port as seen by the application server, or the private (local) and any public (observed) IP addresses in use by the device (this information can be obtained by various means, for example from some DNS servers).
+        
+        If the allocated and observed IP addresses are the same (i.e. NAT is not in use) then  the same address should be specified for both publicAddress and privateAddress.
+        
+        If NAT64 is in use, the device should be identified by its publicAddress and publicPort, or separately by its allocated IPv6 address (field ipv6Address of the Device object)
+      
+        In all cases, publicAddress must be specified, along with at least one of either privateAddress or publicPort, dependent upon which is known. In general, mobile devices cannot be identified by their public IPv4 address alone.
+
+    SingleIpv4Addr:
       type: string
-      format: ipv4
+      description: A single IPv4 address with no subnet mask
+      example: "84.125.93.10"
+      pattern: '^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$'
+
+    Ipv4Address:
+      type: string
       pattern: '^([01]?\d\d?|2[0-4]\d|25[0-5])(?:\.(?:[01]?\d\d?|2[0-4]\d|25[0-5])){3}(\/([0-9]|[1-2][0-9]|3[0-2]))?$'
-      example: '192.168.0.1/24'
+      example: "192.168.0.1/24"
       description: |
         IPv4 address may be specified in form <address/mask> as:
           - address - an IPv4 number in dotted-quad form 1.2.3.4. Only this exact IP number will match the flow control rule.
           - address/mask - an IP number as above with a mask width of the form 1.2.3.4/24.
             In this case, all IP numbers from 1.2.3.0 to 1.2.3.255 will match. The bit width MUST be valid for the IP version.
-    Ipv6Addr:
+
+    Ipv6Address:
       type: string
-      format: ipv6
       allOf:
         - pattern: '^((:|(0?|([1-9a-f][0-9a-f]{0,3}))):)((0?|([1-9a-f][0-9a-f]{0,3})):){0,6}(:|(0?|([1-9a-f][0-9a-f]{0,3})))(\/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))?$'
         - pattern: '^((([^:]+:){7}([^:]+))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?))(\/.+)?$'
-      example: '2001:db8:85a3:8d3:1319:8a2e:370:7344'
+      example: "2001:db8:85a3:8d3:1319:8a2e:370:7344"
       description: |
         IPv6 address, following IETF 5952 format, may be specified in form <address/mask> as:
           - address - The /128 subnet is optional for single addresses:
@@ -147,6 +178,11 @@ components:
           - address/mask - an IP v6 number with a mask:
             - 2001:db8:85a3:8d3::0/64
             - 2001:db8:85a3:8d3::/64
+
+    NetworkAccessIdentifier:
+      type: string
+      example: "123456789@domain.com"
+
     Port:
       type: integer
       minimum: 0

--- a/code/API_definitions/Get DeviceLocation.yaml
+++ b/code/API_definitions/Get DeviceLocation.yaml
@@ -97,8 +97,6 @@ components:
       properties:
         device:
           $ref: '#/components/schemas/Device'
-        devicePort:
-          $ref: '#/components/schemas/Port'
       required:
         - device
 
@@ -153,16 +151,6 @@ components:
       description: A single IPv4 address with no subnet mask
       example: "84.125.93.10"
       pattern: '^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$'
-
-    Ipv4Address:
-      type: string
-      pattern: '^([01]?\d\d?|2[0-4]\d|25[0-5])(?:\.(?:[01]?\d\d?|2[0-4]\d|25[0-5])){3}(\/([0-9]|[1-2][0-9]|3[0-2]))?$'
-      example: "192.168.0.1/24"
-      description: |
-        IPv4 address may be specified in form <address/mask> as:
-          - address - an IPv4 number in dotted-quad form 1.2.3.4. Only this exact IP number will match the flow control rule.
-          - address/mask - an IP number as above with a mask width of the form 1.2.3.4/24.
-            In this case, all IP numbers from 1.2.3.0 to 1.2.3.255 will match. The bit width MUST be valid for the IP version.
 
     Ipv6Address:
       type: string

--- a/code/API_definitions/Get DeviceLocation.yaml
+++ b/code/API_definitions/Get DeviceLocation.yaml
@@ -208,7 +208,7 @@ components:
           type: number
           description: Expected accuracy for the location in meters, from the point defined by latitude/longitude
         lastLocationTime: 
-          description: last date and time when the device was localized (using ISO 8601 with timezone)
+          description: Last date and time when the device was localized (using ISO 8601 with timezone)
           type: string
           format: datetime
     ErrorInfo:

--- a/code/API_definitions/Get DeviceLocation.yaml
+++ b/code/API_definitions/Get DeviceLocation.yaml
@@ -206,7 +206,8 @@ components:
           example: 7.10066     
         accuracy:
           type: number
-          description: Expected accuracy for the location in meters, from the point defined by latitude/longitude
+          description: Provided accuracy for the location, in meters, from the point defined by latitude/longitude
+
         lastLocationTime: 
           description: Last date and time when the device was localized (using ISO 8601 with timezone)
           type: string

--- a/code/API_definitions/Get DeviceLocation.yaml
+++ b/code/API_definitions/Get DeviceLocation.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: Retrieve Device location API
+  title: Device location retrieval API
   description: Service Enabling Network Function API for location retrieval from a device identifier.
   termsOfService: http://swagger.io/terms/
   contact:
@@ -14,8 +14,6 @@ externalDocs:
   url: https://github.com/camaraproject/
 security:
   - oAuth2ClientCredentials: []
-#  - BasicAuth: []
-#  - apiKey: []
   - three_legged:
     - location-retrieval-read
 servers:

--- a/code/API_definitions/Get DeviceLocation.yaml
+++ b/code/API_definitions/Get DeviceLocation.yaml
@@ -1,0 +1,243 @@
+openapi: 3.0.3
+info:
+  title: Get Device location API
+  description: Service Enabling Network Function API for location retrieval from a device identifier.
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: project-email@sample.com
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  version: 0.1.0-wip
+externalDocs:
+  description: Product documentation at Camara
+  url: https://github.com/camaraproject/
+security:
+  - oAuth2ClientCredentials: []
+#  - BasicAuth: []
+#  - apiKey: []
+  - three_legged:
+    - device-location-provide
+servers:
+  - url: '{apiRoot}/{basePath}'
+    variables:
+      apiRoot:
+        default: http://localhost:9091
+        description: API root
+      basePath:
+        default: location/v0
+        description: Base path for the device location API
+paths:
+  /locations:
+    get:
+      tags:
+        - Location retrieval
+      summary: 'Retrieve location for a user equipment'
+      operationId: retrieveLocation
+      description: Retrieve location for an user equipement from an identifier like phone number, IP address (and port) or external identifier provided by the network operator.
+      parameters:
+          - description: Subscriber number in E.164 format (starting with country code). Optionally prefixed with '+'.
+            name: phoneNumber
+            in : query
+            schema: 
+              type: string
+              pattern: '^\+?[0-9]{5,15}$'
+          - description: Identifier assigned by the mobile network operator (MNO) for the device 
+            name: networkAccessIdentifier
+            in: query
+            schema:
+              type: string
+          - description:  |
+              IPv6 address, following IETF 5952 format, may be specified in form <address/mask> as:
+                - address - The /128 subnet is optional for single addresses:
+                  - 2001:db8:85a3:8d3:1319:8a2e:370:7344
+                  - 2001:db8:85a3:8d3:1319:8a2e:370:7344/128
+                - address/mask - an IP v6 number with a mask:
+                  - 2001:db8:85a3:8d3::0/64
+                  - 2001:db8:85a3:8d3::/64
+            name: ipv6Address
+            in : query
+            schema:
+              type: string
+              pattern: 
+                -'^((:|(0?|([1-9a-f][0-9a-f]{0,3}))):)((0?|([1-9a-f][0-9a-f]{0,3})):){0,6}(:|(0?|([1-9a-f][0-9a-f]{0,3})))(\/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))?$'
+                -'^((([^:]+:){7}([^:]+))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?))(\/.+)?$'
+          - description: |
+              IPv4 address may be specified in form <address/mask> as:
+              - address - an IPv4 number in dotted-quad form 1.2.3.4. Only this exact IP number will match the flow control rule.
+              - address/mask - an IP number as above with a mask width of the form 1.2.3.4/24.
+              In this case, all IP numbers from 1.2.3.0 to 1.2.3.255 will match. The bit width MUST be valid for the IP version.
+            name: Ipv4Address
+            in : query
+            schema:
+              type: string
+              pattern: 
+                -'^((:|(0?|([1-9a-f][0-9a-f]{0,3}))):)((0?|([1-9a-f][0-9a-f]{0,3})):){0,6}(:|(0?|([1-9a-f][0-9a-f]{0,3})))(\/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))?$'
+                -'^((([^:]+:){7}([^:]+))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?))(\/.+)?$'
+          - description: User equipment port. Device port may be required along with IP address to identify the target device
+            name: port
+            in : query
+            schema:
+              type: integer
+              minimum: 0
+              maximum: 65535
+      responses:
+        '200':
+          description: Location retrieval result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetrievalLocationResponse'
+              examples: 
+                'success':
+                  summary: successful location
+                  description: The network provides device location
+                  value:
+                    latitude: 50.735851
+                    longitude: 7.10066
+                    accuracy: 2
+
+        '400':
+          $ref: '#/components/responses/Generic400'
+        '401':
+          $ref: '#/components/responses/Generic401'
+        '403':
+          $ref: '#/components/responses/Generic403'
+        '404':
+          $ref: '#/components/responses/Generic404'
+        '500':
+          $ref: '#/components/responses/Generic500'
+        '503':
+          $ref: '#/components/responses/Generic503'
+components:
+  securitySchemes:
+    oAuth2ClientCredentials:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: '{tokenUrl}'
+          scopes: {}
+#    BasicAuth:
+#      type: http
+#      scheme: basic
+#    apiKey:
+#      type: apiKey
+#      description: API key to authorize requests
+#      name: apikey
+#      in: query
+    three_legged:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://auth.example.com/authorize
+          tokenUrl: https://auth.example.com/token
+          scopes:
+            device-location-provide: Provide device location
+  schemas:
+    RetrievalLocationResponse:
+      type: object
+      required:
+        - latitude
+        - longitude
+        - accuracy
+      properties:
+        latitude:
+          description: Latitude component of a location
+          type: number
+          format: double
+          minimum: -90
+          maximum: 90
+          example: 50.735851      
+        longitude:
+          description: Longitude component of location
+          type: number
+          format: double
+          minimum: -180
+          maximum: 180
+          example: 7.10066     
+        accuracy:
+          type: number
+          description: Expected accuracy for the location in km, from the point defined by latitude/longitude
+    Port:
+      type: integer
+      minimum: 0
+      maximum: 65535
+      description: User equipment port. Device port may be required along with IP address to identify the target device
+      example: 5060
+    ErrorInfo:
+      type: object
+      required:
+        - status
+        - code
+        - message
+      properties:
+        status:
+          type: integer
+          description: HTTP status code returned along with this error response
+        code:
+          type: string
+          description: Code given to this error
+        message:
+          type: string
+          description: Detailed error description
+  responses:
+    Generic400:
+      description: Invalid input
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInfo'
+          example:
+            status: 400
+            code: INVALID_ARGUMENT
+            message: 'Invalid input'
+    Generic401:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInfo'
+          example:
+            status: 401
+            code: UNAUTHENTICATED
+            message: 'Authorization failed: ...'
+    Generic403:
+      description: Forbidden
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInfo'
+          example:
+            status: 403
+            code: PERMISSION_DENIED
+            message: 'Operation not allowed: ...'
+    Generic404:
+      description: Not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInfo'
+          example:
+            status: 404
+            code: NOT_FOUND
+            message: 'The specified resource is not found'
+    Generic500:
+      description: Internal server error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInfo'
+          example:
+            status: 500
+            code: INTERNAL
+            message: 'Internal server error'
+    Generic503:
+      description: Service unavailable
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInfo'
+          example:
+            status: 503
+            code: UNAVAILABLE
+            message: 'Service unavailable'

--- a/code/API_definitions/Get DeviceLocation.yaml
+++ b/code/API_definitions/Get DeviceLocation.yaml
@@ -28,7 +28,7 @@ servers:
         default: location/v0
         description: Base path for the device location API
 paths:
-  /location:
+  /retrieve-location:
     post:
       tags:
         - Location retrieval


### PR DESCRIPTION
First stab for API definition for **retrieving a device location**. There are points to be commented in this PR and discussed in team meeting:

- I've not yet provided any documentation - will do once we agreed on the interface directly in the OAS.
- Use of device identifiers as defined in latest QoD version (phoneNumber an not MSISDN) - this introduce a gap with the check api.
- Definition of a specific scope distinct from the check operation
- In the response only lat/log & accuracy are provided. I opted to provided straightforward information and not use area schema (with oneOf) --> could be challenged.
- We need some update on the other api - for example the little for the existing api should be check device location API instead of device location API. 
- etc.
