### PR TITLE
fix: reference to the correct branch "release-v0.1.0" for release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,8 @@
 
 **This is the first alpha version of the DeviceLocation API.** 
 
-- API [definition](https://github.com/camaraproject/DeviceLocation/tree/release-0.1.0/code/API_definitions)
-- API [documentation](https://github.com/camaraproject/DeviceLocation/tree/release-0.1.0/documentation/API_documentation)
+- API [definition](https://github.com/camaraproject/DeviceLocation/tree/release-v0.1.0/code/API_definitions)
+- API [documentation](https://github.com/camaraproject/DeviceLocation/tree/release-v0.1.0/documentation/API_documentation)
 
 ## Please note:
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Repository to describe, develop, document and test the DeviceLocation API family
     - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/blob/release-0.2.0-rc2/code/API_definitions/geofencing.yaml&nocors)
     - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/blob/release-0.2.0-rc2/code/API_definitions/geofencing.yaml)
 
-* The previous release version v0.1.0 of DeviceLocation API is available within the [release-0.1.0 branch](https://github.com/camaraproject/DeviceLocation/tree/release-0.1.0)
+* The previous release version v0.1.0 of DeviceLocation API is available within the [release-0.1.0 branch](https://github.com/camaraproject/DeviceLocation/tree/release-v0.1.0)
   - This past release only included the first alpha version of the API now renamed to location-verification, but it was then named as "location v0.1.0"
 
 ## Contributorship and mailing list


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction


#### What this PR does / why we need it:
Fix the link to the correct branch for release 0.1.0.

The current path leads to 404.

