### PR TITLE
Minor update - changing "polygon" to "POLYGON" in example to align with enum case

### DIFF
--- a/code/API_definitions/location-retrieval.yaml
+++ b/code/API_definitions/location-retrieval.yaml
@@ -408,7 +408,7 @@ components:
       value:
         lastLocationTime: 2023-10-17T13:18:23.682Z
         area:
-          areaType: polygon
+          areaType: POLYGON
           boundary:
             - latitude: 45.754114
               longitude: 4.860374


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction



#### What this PR does / why we need it:

Very small update. Updating the "RETRIEVAL_POLYGON" example - changed "polygon" to "POLYGON" to align with expected enum String. The RETRIEVAL_POLYGON response example was failing Schema validation in local mock tool ([Prism](https://github.com/stoplightio/prism)).

#### Changelog input

```
 release-note
Updated examples/RETRIEVAL_POLYGON - changed "polygon" to "POLYGON"

```



