### PR TITLE
fix: correct $ref for SubscriptionEventType in geofencing

### DIFF
--- a/code/API_definitions/geofencing.yaml
+++ b/code/API_definitions/geofencing.yaml
@@ -63,7 +63,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.2.0-wip
+  version: 0.1.0-rc3
 externalDocs:
   description: Product documentation at Camara
   url: https://github.com/camaraproject/

--- a/code/API_definitions/geofencing.yaml
+++ b/code/API_definitions/geofencing.yaml
@@ -450,7 +450,7 @@ components:
         area:
           $ref: "#/components/schemas/Area"
         type:
-          $ref: "#/components/schemas/SubcriptionEventType"
+          $ref: "#/components/schemas/SubscriptionEventType"
       required:
         - device
         - area

--- a/code/API_definitions/geofencing.yaml
+++ b/code/API_definitions/geofencing.yaml
@@ -63,7 +63,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.1.0-rc2
+  version: 0.2.0-wip
 externalDocs:
   description: Product documentation at Camara
   url: https://github.com/camaraproject/


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* bug



#### What this PR does / why we need it:
Fixes the reference to the component SubscriptionEventType


