### PR TITLE
feat: add subscriptionMaxEvents for maximum number of notifications (geofencing)

### DIFF
--- a/code/API_definitions/geofencing.yaml
+++ b/code/API_definitions/geofencing.yaml
@@ -43,7 +43,11 @@ info:
     
     Note: Additionally to these list, ``org.camaraproject.geofencing.v0.subscription-ends`` notification `type` is sent when the subscription ends. 
     This notification did not requires dedicated subscription. 
-    It is used when the subscription expire time (required by the requester) has been reached or if the API server has to stop sending notification prematurely. 
+
+    It is used when:
+      - the subscription expire time (required by the requester) has been reached 
+      - the maximum number of subscription events (optionally set by the requester) has been reached
+      - the API server has to stop sending notification prematurely
 
     ### Notification callback
 
@@ -63,7 +67,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.1.0
+  version: 0.2.0-wip
 externalDocs:
   description: Product documentation at Camara
   url: https://github.com/camaraproject/
@@ -504,6 +508,9 @@ components:
           description: The date time when the location-tracking has to be terminated. 
             It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone. 
             Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z)
+        subscriptionMaxEvents:
+          type: integer
+          description: Identifies the maximum number of event reports to be generated (>=1) - Once this number is reached, the subscription ends.
       required:
         - webhook
         - subscriptionDetail


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* enhancement/feature


#### What this PR does / why we need it:
Based on the updated [guidelines](https://github.com/camaraproject/Commonalities/blob/main/documentation/API-design-guidelines.md#12-subscription-notification--event) the subscriptionMaxEvents is added as an optional parameter to define after how many events the subscription will end.



#### Which issue(s) this PR fixes:

Fixes #111 