### PR TITLE
Remove API from title and align use of Device as prefix

### DIFF
--- a/code/API_definitions/geofencing.yaml
+++ b/code/API_definitions/geofencing.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: Device geofencing API
+  title: Device Geofencing
   description: |
     API to create, retrieve and delete event subscriptions to realize geofencing for a user device.
     

--- a/code/API_definitions/location-retrieval.yaml
+++ b/code/API_definitions/location-retrieval.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: Location retrieval API
+  title: Device Location Retrieval
   description: |
     This API provides the ability to retrieve a device location. 
 

--- a/code/API_definitions/location-verification.yaml
+++ b/code/API_definitions/location-verification.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: Device location verification API
+  title: Device Location Verification
   description: |
     This API provides the customer with the ability to verify the location of a device. 
 


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

Align info.title values in the 3 APIs:
- Remove API as suffix
- Add Device as prefix for location-retrieval which was the only one without it
- Use Upper Case for every word, as this is used by most of CAMARA APIs


#### Which issue(s) this PR fixes:

Fixes #169 

