### PR TITLE
Update location-retrieval for lastLocationTime documentation cardinality

### DIFF
--- a/code/API_definitions/location-retrieval.yaml
+++ b/code/API_definitions/location-retrieval.yaml
@@ -37,7 +37,7 @@ info:
 
     * **Max Age**: Maximum age of the location information which is accepted for the location retrieval (in seconds).
 
-      * Absence of maxAge means "any age" is acceptable for the client. In other words, this is like maxAge=infinite. The system still return lastLocationTime in the response. If the system is not able to provide location a error 404 with code LOCATION_RETRIEVAL.DEVICE_NOT_FOUND is send back.
+      * Absence of maxAge means "any age" is acceptable for the client. In other words, this is like maxAge=infinite. The system returns lastLocationTime in the response. If the system is not able to provide location a error 404 with code LOCATION_RETRIEVAL.DEVICE_NOT_FOUND is send back.
       * maxAge=0 means a fresh calculation is requested by the client. If the system is not able to provide fresh location an error 422 with code LOCATION_RETRIEVAL.UNABLE_TO_FULFILL_MAX_AGE is send back.
 
     * **Last Location Time** : Last date and time when the device was localized.

--- a/code/API_definitions/location-retrieval.yaml
+++ b/code/API_definitions/location-retrieval.yaml
@@ -37,7 +37,7 @@ info:
 
     * **Max Age**: Maximum age of the location information which is accepted for the location retrieval (in seconds).
 
-      * Absence of maxAge means "any age" is acceptable for the client. In other words, this is like maxAge=infinite. In this case the system may still return lastLocationTime, if available. If the system is not able to provide location a error 404 with code LOCATION_RETRIEVAL.DEVICE_NOT_FOUND is send back.
+      * Absence of maxAge means "any age" is acceptable for the client. In other words, this is like maxAge=infinite. The system still return lastLocationTime in the response. If the system is not able to provide location a error 404 with code LOCATION_RETRIEVAL.DEVICE_NOT_FOUND is send back.
       * maxAge=0 means a fresh calculation is requested by the client. If the system is not able to provide fresh location an error 422 with code LOCATION_RETRIEVAL.UNABLE_TO_FULFILL_MAX_AGE is send back.
 
     * **Last Location Time** : Last date and time when the device was localized.

--- a/code/API_definitions/location-retrieval.yaml
+++ b/code/API_definitions/location-retrieval.yaml
@@ -37,7 +37,7 @@ info:
 
     * **Max Age**: Maximum age of the location information which is accepted for the location retrieval (in seconds).
 
-      * Absence of maxAge means "any age" is acceptable for the client. In other words, this is like maxAge=infinite. The system returns lastLocationTime in the response. If the system is not able to provide location a error 404 with code LOCATION_RETRIEVAL.DEVICE_NOT_FOUND is send back.
+      * Absence of `maxAge` means that "any age" is acceptable for the client. In other words, this is like `maxAge`=infinite. The system will return `lastLocationTime` in the response. If the system is not able to provide location, an error 404 with code LOCATION_RETRIEVAL.DEVICE_NOT_FOUND is sent back.
       * maxAge=0 means a fresh calculation is requested by the client. If the system is not able to provide fresh location an error 422 with code LOCATION_RETRIEVAL.UNABLE_TO_FULFILL_MAX_AGE is send back.
 
     * **Last Location Time** : Last date and time when the device was localized.

--- a/code/API_definitions/location-retrieval.yaml
+++ b/code/API_definitions/location-retrieval.yaml
@@ -38,7 +38,7 @@ info:
     * **Max Age**: Maximum age of the location information which is accepted for the location retrieval (in seconds).
 
       * Absence of `maxAge` means that "any age" is acceptable for the client. In other words, this is like `maxAge`=infinite. The system will return `lastLocationTime` in the response. If the system is not able to provide location, an error 404 with code LOCATION_RETRIEVAL.DEVICE_NOT_FOUND is sent back.
-      * maxAge=0 means a fresh calculation is requested by the client. If the system is not able to provide fresh location an error 422 with code LOCATION_RETRIEVAL.UNABLE_TO_FULFILL_MAX_AGE is send back.
+      * `maxAge`=0 means that a fresh calculation is requested by the client. If the system is not able to provide the fresh location, an error 422 with code LOCATION_RETRIEVAL.UNABLE_TO_FULFILL_MAX_AGE is sent back.
 
     * **Last Location Time** : Last date and time when the device was localized.
 


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* correction


#### What this PR does / why we need it:

Align the documentation part of the API with the fact that `lastLocationTime` is mandatory in all response.
See line 40

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #197 

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
