### PR TITLE
Update `maxAge`-behaviour for `/verify` & `/retrieve`

### DIFF
--- a/code/API_definitions/location-retrieval.yaml
+++ b/code/API_definitions/location-retrieval.yaml
@@ -55,7 +55,7 @@ info:
     # Further info and support
 
     (FAQs will be added in a later version of the documentation)
-  termsOfService: http://swagger.io/terms/
+  termsOfService: https://swagger.io/terms/
   contact:
     email: project-email@sample.com
   license:
@@ -366,11 +366,6 @@ components:
                 status: 400
                 code: INVALID_ARGUMENT
                 message: "Invalid argument"
-            MaxAgeIssue:
-              value:
-                status: 400
-                code: LOCATION_RETRIEVAL.MAXAGE_INVALID_ARGUMENT
-                message: "maxAge threshold cannot be satisfied"
     Generic401:
       description: Unauthenticated
       headers:
@@ -429,7 +424,7 @@ components:
           example:
             status: 422
             code: LOCATION_RETRIEVAL.UNABLE_TO_FULFILL_MAX_AGE
-            message: "Unable to provide expected frehsness for location"
+            message: "Unable to provide expected freshness for location"
     Generic500:
       description: Internal server error
       headers:

--- a/code/API_definitions/location-verification.yaml
+++ b/code/API_definitions/location-verification.yaml
@@ -539,7 +539,7 @@ components:
           examples:
             LOCATION_VERIFICATION_422_UNABLE_TO_FULFILL_MAX_AGE:
               summary: Unable to fulfill maxAge
-              description: the system is not able to provide the fresh location required by the client
+              description: The system is not able to provide the fresh location required by the client
               value:
                 status: 422
                 code: LOCATION_VERIFICATION.UNABLE_TO_FULFILL_MAX_AGE

--- a/code/API_definitions/location-verification.yaml
+++ b/code/API_definitions/location-verification.yaml
@@ -49,7 +49,7 @@ info:
     # Further info and support
 
     (FAQs will be added in a later version of the documentation)
-  termsOfService: http://swagger.io/terms/
+  termsOfService: https://swagger.io/terms/
   contact:
     email: project-email@sample.com
   license:
@@ -162,6 +162,8 @@ paths:
           $ref: "#/components/responses/Generic403"
         "404":
           $ref: "#/components/responses/Generic404"
+        "422":
+          $ref: "#/components/responses/RetrieveLocationUnprocessableEntity422"
         "500":
           $ref: "#/components/responses/Generic500"
         "503":
@@ -456,6 +458,19 @@ components:
             status: 404
             code: NOT_FOUND
             message: "The specified resource is not found"
+    RetrieveLocationUnprocessableEntity422:
+      description: Unprocessable Entity
+      headers:
+        x-correlator:
+          $ref: '#/components/headers/x-correlator'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInfo'
+          example:
+            status: 422
+            code: LOCATION_RETRIEVAL.UNABLE_TO_FULFILL_MAX_AGE
+            message: "Unable to provide expected freshness for location"
     Generic500:
       description: Internal server error
       headers:

--- a/code/API_definitions/location-verification.yaml
+++ b/code/API_definitions/location-verification.yaml
@@ -469,7 +469,7 @@ components:
             $ref: '#/components/schemas/ErrorInfo'
           example:
             status: 422
-            code: LOCATION_RETRIEVAL.UNABLE_TO_FULFILL_MAX_AGE
+            code: LOCATION_VERIFICATION.UNABLE_TO_FULFILL_MAX_AGE
             message: "Unable to provide expected freshness for location"
     Generic500:
       description: Internal server error

--- a/code/API_definitions/location-verification.yaml
+++ b/code/API_definitions/location-verification.yaml
@@ -34,8 +34,7 @@ info:
 
      * **Max Age**: Maximum age of the location information which is accepted for the location verification (in seconds).
         * Absence of maxAge means "any age" is acceptable for the client. In other words, this is like maxAge=infinite. In this case the system may still return lastLocationTime, if available.
-        * maxAge=0 means a fresh calculation is requested by the client.
-          If the system does not support it, or fresh location cannot be checked at that time for any reason, the API response will be "UNKNOWN" and the `lastLocationTime` attribute may indicate the last available time for the device location.
+        * maxAge=0 means a fresh calculation is requested by the client. If the system is not able to provide the fresh location, an error 422 with code LOCATION_VERIFICATION.UNABLE_TO_FULFILL_MAX_AGE is sent back.
 
 
     * **Verification**: Process triggered in the API server to confirm or contradict the expectation assumed by the API client about the device location.

--- a/code/API_definitions/location-verification.yaml
+++ b/code/API_definitions/location-verification.yaml
@@ -163,7 +163,7 @@ paths:
         "404":
           $ref: "#/components/responses/Generic404"
         "422":
-          $ref: "#/components/responses/RetrieveLocationUnprocessableEntity422"
+          $ref: "#/components/responses/VerifyLocationUnprocessableEntity422"
         "500":
           $ref: "#/components/responses/Generic500"
         "503":
@@ -458,7 +458,7 @@ components:
             status: 404
             code: NOT_FOUND
             message: "The specified resource is not found"
-    RetrieveLocationUnprocessableEntity422:
+    VerifyLocationUnprocessableEntity422:
       description: Unprocessable Entity
       headers:
         x-correlator:

--- a/code/API_definitions/location-verification.yaml
+++ b/code/API_definitions/location-verification.yaml
@@ -536,10 +536,49 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ErrorInfo"
-          example:
-            status: 422
-            code: LOCATION_VERIFICATION.UNABLE_TO_FULFILL_MAX_AGE
-            message: "Unable to provide expected freshness for location"
+          examples:
+            LOCATION_VERIFICATION_422_UNABLE_TO_FULFILL_MAX_AGE:
+              summary: Unable to fulfill maxAge
+              description: the system is not able to provide the fresh location required by the client
+              value:
+                status: 422
+                code: LOCATION_VERIFICATION.UNABLE_TO_FULFILL_MAX_AGE
+                message: "Unable to provide expected freshness for location"
+            GENERIC_422_UNPROCESSABLE_ENTITY:
+              summary: Unprocessable entity
+              description: The request was well-formed but was unable to be processed due to semantic errors or not applicable values. This is the generic error code for 422 responses.
+              value:
+                status: 422
+                code: UNPROCESSABLE_ENTITY
+                message: "Value not acceptable: ..."
+            GENERIC_422_DEVICE_NOT_APPLICABLE:
+              summary: Service not applicable to the device
+              description: The provided device is not compatible with the requested operation, according to the service provider rules.
+              value:
+                status: 422
+                code: DEVICE_NOT_APPLICABLE
+                message: "The device is not applicable for the requested operation"
+            GENERIC_422_DEVICE_IDENTIFIERS_MISMATCH:
+              summary: Device identifiers mismatch
+              description: Several device identifiers are provided but do not match the same device
+              value:
+                status: 422
+                code: DEVICE_IDENTIFIERS_MISMATCH
+                message: "The provided device identifiers do not match the same device"
+            GENERIC_422_UNSUPPORTED_DEVICE_IDENTIFIERS:
+              summary: None of the provided device identifiers is supported by the implementation
+              description: Message may list the supported device identifiers
+              value:
+                status: 422
+                code: UNSUPPORTED_DEVICE_IDENTIFIERS
+                message: "Supported device supported are: ..."
+            GENERIC_422_UNIDENTIFIABLE_DEVICE:
+              summary: No identifier provided
+              description: No device identifier provided for the device to be located
+              value:
+                status: 422
+                code: UNIDENTIFIABLE_DEVICE
+                message: "A device must be provided"
 
     Generic500:
       description: Internal server error

--- a/code/API_definitions/location-verification.yaml
+++ b/code/API_definitions/location-verification.yaml
@@ -85,7 +85,7 @@ paths:
         Verify whether the location of a device is within a requested area. The operation returns a verification result and, optionally, a match rate estimation for the location verification in percent.
       operationId: verifyLocation
       parameters:
-        - $ref: '#/components/parameters/x-correlator'
+        - $ref: "#/components/parameters/x-correlator"
       requestBody:
         required: true
         content:
@@ -125,7 +125,7 @@ paths:
           description: Location verification result
           headers:
             x-correlator:
-              $ref: '#/components/headers/x-correlator'
+              $ref: "#/components/headers/x-correlator"
           content:
             application/json:
               schema:
@@ -531,11 +531,11 @@ components:
       description: Unprocessable Entity
       headers:
         x-correlator:
-          $ref: '#/components/headers/x-correlator'
+          $ref: "#/components/headers/x-correlator"
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorInfo'
+            $ref: "#/components/schemas/ErrorInfo"
           example:
             status: 422
             code: LOCATION_VERIFICATION.UNABLE_TO_FULFILL_MAX_AGE


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction


#### What this PR does / why we need it:
Updating the `maxAge`-behaviour for location-verification and location-retrieval



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #216 