### PR TITLE
Add handling when the requested geofence `area` cannot be covered

### DIFF
--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -913,7 +913,7 @@ components:
       type: string
       description: |
         - NETWORK_TERMINATED - API server stopped sending notification
-        - SUBSCRIPTION_CREATION_ABORTED - Subscription cannot be created because the specified area cannot be managed (for asynchronous subscription creation) 
+        - SUBSCRIPTION_CREATION_ABORTED - Subscription cannot be created because the specified area cannot be managed (for asynchronous subscription creation)
         - SUBSCRIPTION_EXPIRED - Subscription expire time (optionally set by the requester) has been reached
         - MAX_EVENTS_REACHED - Maximum number of events (optionally set by the requester) has been reached
         - ACCESS_TOKEN_EXPIRED - Access Token sinkCredential (optionally set by the requester) expiration time has been reached

--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -1106,11 +1106,6 @@ components:
                 status: 400
                 code: "INVALID_TOKEN"
                 message: "Only bearer token is supported"
-            AreaNotCovered:
-              value:
-                status: 400
-                code: "AREA_NOT_COVERED"
-                message: "The specified area cannot be covered or is too small to be valid"
 
     Generic400:
       description: Problem with the client request
@@ -1239,6 +1234,11 @@ components:
                 status: 422
                 code: "MULTIEVENT_SUBSCRIPTION_NOT_SUPPORTED"
                 message: "Multi event types subscription not managed"
+            AreaNotCovered:
+              value:
+                status: 422
+                code: "AREA_NOT_COVERED"
+                message: "The specified area cannot be covered or is too small to be valid"
     Generic429:
       description: Too Many Requests
       headers:

--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -140,6 +140,8 @@ paths:
                         $ref: "#/components/examples/CIRCLE_AREA_LEFT"
                       SUBSCRIPTION_ENDS:
                         $ref: "#/components/examples/SUBSCRIPTION_ENDS"
+                      SUBSCRIPTION_UNPROCESSABLE:
+                        $ref: "#/components/examples/SUBSCRIPTION_UNPROCESSABLE"
               responses:
                 "204":
                   description: Successful notification
@@ -923,7 +925,7 @@ components:
       type: string
       description: |
         - NETWORK_TERMINATED - API server stopped sending notification
-        - SUBSCRIPTION_CREATION_ABORTED - Subscription cannot be created because the specified area cannot be managed (for asynchronous subscription creation)
+        - SUBSCRIPTION_UNPROCESSABLE - Subscription cannot be processed because the specified area cannot be managed (for asynchronous subscription creation)
         - SUBSCRIPTION_EXPIRED - Subscription expire time (optionally set by the requester) has been reached
         - SUBSCRIPTION_DELETED - Subscription was deleted by the requester
         - MAX_EVENTS_REACHED - Maximum number of events (optionally set by the requester) has been reached
@@ -931,7 +933,7 @@ components:
       enum:
         - MAX_EVENTS_REACHED
         - NETWORK_TERMINATED
-        - SUBSCRIPTION_CREATION_ABORTED
+        - SUBSCRIPTION_UNPROCESSABLE
         - SUBSCRIPTION_EXPIRED
         - SUBSCRIPTION_DELETED
         - ACCESS_TOKEN_EXPIRED
@@ -1380,7 +1382,7 @@ components:
             radius: 2000
           terminationReason: SUBSCRIPTION_EXPIRED
 
-    SUBSCRIPTION_CREATION_ABORTED:
+    SUBSCRIPTION_UNPROCESSABLE:
       description: The cloud event when the subscription process was aborted.
       value:
         id: "123655"
@@ -1398,5 +1400,5 @@ components:
               latitude: 50.735851
               longitude: 7.10066
             radius: 2000
-          terminationReason: SUBSCRIPTION_CREATION_ABORTED
+          terminationReason: SUBSCRIPTION_UNPROCESSABLE
           terminationDescription: The requested area cannot be covered by the network.

--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -49,6 +49,7 @@ info:
       - the maximum number of subscription events (optionally set by the requester) has been reached
       - the Access Token `sinkCredential` (optionally set by the requester) expiration time has been reached
       - the API server has to stop sending notification prematurely
+      - the specified geofence-`area` cannot be covered or is too small to be managed
 
     ### Notification callback
 
@@ -912,12 +913,14 @@ components:
       type: string
       description: |
         - NETWORK_TERMINATED - API server stopped sending notification
+        - SUBSCRIPTION_CREATION_ABORTED - Subscription cannot be created because the specified area cannot be managed (for asynchronous subscription creation) 
         - SUBSCRIPTION_EXPIRED - Subscription expire time (optionally set by the requester) has been reached
         - MAX_EVENTS_REACHED - Maximum number of events (optionally set by the requester) has been reached
         - ACCESS_TOKEN_EXPIRED - Access Token sinkCredential (optionally set by the requester) expiration time has been reached
       enum:
         - MAX_EVENTS_REACHED
         - NETWORK_TERMINATED
+        - SUBSCRIPTION_CREATION_ABORTED
         - SUBSCRIPTION_EXPIRED
         - ACCESS_TOKEN_EXPIRED
 
@@ -1103,6 +1106,12 @@ components:
                 status: 400
                 code: "INVALID_TOKEN"
                 message: "Only bearer token is supported"
+            AreaNotCovered:
+              value:
+                status: 400
+                code: "AREA_NOT_COVERED"
+                message: "The specified area cannot be covered or is too small to be valid"
+
     Generic400:
       description: Problem with the client request
       headers:
@@ -1364,4 +1373,30 @@ components:
           subscriptionId: 987654321
           device:
             phoneNumber: +123456789
+          area:
+            areaType: CIRCLE
+            center:
+              latitude: 50.735851
+              longitude: 7.10066
+            radius: 2000
           terminationReason: SUBSCRIPTION_EXPIRED
+
+    SUBSCRIPTION_CREATION_ABORTED:
+      description: The cloud event when the subscription process was aborted.
+      value:
+        id: "123655"
+        source: https://notificationSendServer12.supertelco.com
+        type: org.camaraproject.geofencing-subscriptions.v0.subscription-ends
+        specversion: "1.0"
+        datacontenttype: application/json
+        time: 2023-03-22T05:40:23.682Z
+        data:
+          device:
+            phoneNumber: +123456789
+          area:
+            areaType: CIRCLE
+            center:
+              latitude: 50.735851
+              longitude: 7.10066
+            radius: 2000
+          terminationReason: SUBSCRIPTION_CREATION_ABORTED

--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -913,6 +913,9 @@ components:
           $ref: "#/components/schemas/Area"
         terminationReason:
           $ref: "#/components/schemas/TerminationReason"
+        terminationDescription:
+          description: Explanation why a subscription ended or had to end.
+          type: string
         subscriptionId:
           $ref: "#/components/schemas/SubscriptionId"
 
@@ -1396,3 +1399,4 @@ components:
               longitude: 7.10066
             radius: 2000
           terminationReason: SUBSCRIPTION_CREATION_ABORTED
+          terminationDescription: The requested area cannot be covered by the network.

--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -1106,7 +1106,6 @@ components:
                 status: 400
                 code: "INVALID_TOKEN"
                 message: "Only bearer token is supported"
-
     Generic400:
       description: Problem with the client request
       headers:

--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -925,7 +925,7 @@ components:
       type: string
       description: |
         - NETWORK_TERMINATED - API server stopped sending notification
-        - SUBSCRIPTION_UNPROCESSABLE - Subscription cannot be processed because the specified area cannot be managed (for asynchronous subscription creation)
+        - SUBSCRIPTION_UNPROCESSABLE - Subscription cannot be processed due to some reason, e.g. because the specified area cannot be managed. Useful for asynchronous subscription creation.
         - SUBSCRIPTION_EXPIRED - Subscription expire time (optionally set by the requester) has been reached
         - SUBSCRIPTION_DELETED - Subscription was deleted by the requester
         - MAX_EVENTS_REACHED - Maximum number of events (optionally set by the requester) has been reached


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* enhancement/feature

#### What this PR does / why we need it:
Adds handling when the provided subscription area cannot be covered or is too small to receive any notifications.



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #198 
