### PR TITLE
geofencing: Add `SUBSCRIPTION_DELETED` as termination-reason

### DIFF
--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -47,6 +47,7 @@ info:
     It is used when:
       - the subscription expire time (optionally set by the requester) has been reached
       - the maximum number of subscription events (optionally set by the requester) has been reached
+      - the subscription was deleted by the requester
       - the Access Token `sinkCredential` (optionally set by the requester) expiration time has been reached
       - the API server has to stop sending notification prematurely
 
@@ -921,12 +922,14 @@ components:
       description: |
         - NETWORK_TERMINATED - API server stopped sending notification
         - SUBSCRIPTION_EXPIRED - Subscription expire time (optionally set by the requester) has been reached
+        - SUBSCRIPTION_DELETED - Subscription was deleted by the requester
         - MAX_EVENTS_REACHED - Maximum number of events (optionally set by the requester) has been reached
         - ACCESS_TOKEN_EXPIRED - Access Token sinkCredential (optionally set by the requester) expiration time has been reached
       enum:
         - MAX_EVENTS_REACHED
         - NETWORK_TERMINATED
         - SUBSCRIPTION_EXPIRED
+        - SUBSCRIPTION_DELETED
         - ACCESS_TOKEN_EXPIRED
 
     HTTPSubscriptionRequest:


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* enhancement/feature

#### What this PR does / why we need it:
Adds a new termination-reason for "subscription-ends" - CloudEvent, when the user deletes the subscriptions via 
`DELETE /subscriptions/{subscriptionId}`



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #141 