### PR TITLE
Add Max(DT) to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,7 @@
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
 
-* @bigludo7 @jlurien
+* @bigludo7 @jlurien @maxl2287
 
 # Owners of the CODEOWNER and Maintainer.md files are the admins of CAMARA (to allow them to keep the teams within the CAMARA organization in sync in case of changes)
 /CODEOWNERS @camaraproject/admins


### PR DESCRIPTION
#### What type of PR is this?

* subproject management

#### What this PR does / why we need it:

Add @maxl2287 as codeowner for Device Location

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

This PR duplicates https://github.com/camaraproject/DeviceLocation/pull/236 as that one was not merged against main, but against another branch which is no longer valid

#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
