### PR TITLE
[geofencing-subscriptions]: remove `allOf` in `sinkCredential`

### DIFF
--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -369,9 +369,7 @@ components:
           description: The address to which events shall be delivered using the selected protocol.
           example: "https://endpoint.example.com/sink"
         sinkCredential:
-          allOf:
-            - description: A sink credential provides authentication or authorization information necessary to enable delivery of events to a target.
-            - $ref: "#/components/schemas/SinkCredential"
+          $ref: "#/components/schemas/SinkCredential"
         types:
           description: |
             Camara Event types eligible to be delivered by this subscription.
@@ -429,6 +427,7 @@ components:
 
     SinkCredential:
       type: object
+      description: A sink credential provides authentication or authorization information necessary to enable delivery of events to a target.
       properties:
         credentialType:
           type: string


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* correction


#### What this PR does / why we need it:
Removing this `allOf` aligns with the Commonalities latest version.
It was also discovered that for some code-generators it will produce unexpected behaviors having the `description` inside the `allOf`.



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #264 

#### Changelog input

```
[geofencing-subscriptions]: remove `allOf` in `sinkCredential`
```
