### PR TITLE
[location-verification / geofencing]: decrease radius minimum to "1" for circle-area

### DIFF
--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -8,8 +8,8 @@ info:
 
     With this API, API consumers can create subscriptions for their devices to receive notifications when a device enters or exits a specified area.
 
-    * If the provided area is out of the operator's coverage or it is not supported for any reason, an error `422 GEOFENCING.AREA_NOT_COVERED` will be returned.
-    * Legal restrictions regarding privacy, or other regulatory or implementation issues, may force the operator to set restrictions to the provided area, such as setting a minimum value to the accepted radius. In these cases, an error `422 GEOFENCING.INVALID_AREA` will be returned and the error message will refer to the reason of the limitation.
+    * If the provided area is out of the operator's coverage or it is not supported for any reason, an error `422 GEOFENCING_SUBSCRIPTIONS.AREA_NOT_COVERED` will be returned.
+    * Legal restrictions regarding privacy, or other regulatory or implementation issues, may force the operator to set restrictions to the provided area, such as setting a minimum value to the accepted radius. In these cases, an error `422 GEOFENCING_SUBSCRIPTIONS.INVALID_AREA` will be returned and the error message will refer to the reason of the limitation.
 
     The area provided in the request is described by a circle determined by coordinates (latitude and longitude) and an accuracy defined by the radius.
 
@@ -1333,8 +1333,8 @@ components:
                       - SERVICE_NOT_APPLICABLE
                       - UNNECESSARY_IDENTIFIER
                       - UNSUPPORTED_IDENTIFIER
-                      - GEOFENCING.AREA_NOT_COVERED
-                      - GEOFENCING.INVALID_AREA
+                      - GEOFENCING_SUBSCRIPTIONS.AREA_NOT_COVERED
+                      - GEOFENCING_SUBSCRIPTIONS.INVALID_AREA
           examples:
             GENERIC_422_IDENTIFIER_MISMATCH:
               description: Inconsistency between device identifiers not pointing to the same device.
@@ -1370,14 +1370,14 @@ components:
               description: The system is not able cover the requested area
               value:
                 status: 422
-                code: GEOFENCING.AREA_NOT_COVERED
+                code: GEOFENCING_SUBSCRIPTIONS.AREA_NOT_COVERED
                 message: "Unable to cover the requested area"
             GEOFENCING_422_INVALID_AREA:
               summary: Invalid area
               description: The requested area is too small to be supported by the system.
               value:
                 status: 422
-                code: GEOFENCING.INVALID_AREA
+                code: GEOFENCING_SUBSCRIPTIONS.INVALID_AREA
                 message: "The requested area is too small"
     Generic429:
       description: Too Many Requests

--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -738,7 +738,7 @@ components:
             radius:
               type: integer
               description: |
-                Expected accuracy for the subscription event of device location in m, from location (radius).
+                Expected accuracy for the subscription event of device location, in meters from `center`.
                 Note: The area surface could be restricted locally depending on regulations. Implementations may enforce a larger minimum radius (e.g. 1000 meters).
               minimum: 1
               maximum: 200000

--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -8,6 +8,9 @@ info:
 
     With this API, API consumers can create subscriptions for their devices to receive notifications when a device enters or exits a specified area.
 
+    * If the provided area is out of the operator's coverage or it is not supported for any reason, an error `422 GEOFENCING.AREA_NOT_COVERED` will be returned.
+    * Legal restrictions regarding privacy, or other regulatory or implementation issues, may force the operator to set restrictions to the provided area, such as setting a minimum value to the accepted radius. In these cases, an error `422 GEOFENCING.INVALID_AREA` will be returned and the error message will refer to the reason of the limitation.
+
     The area provided in the request is described by a circle determined by coordinates (latitude and longitude) and an accuracy defined by the radius.
 
     Upon successfully creating a subscription, the API will provide an Event Subscription ID, and it will indicate the subscription's expiration date.
@@ -1325,18 +1328,14 @@ components:
                       - 422
                   code:
                     enum:
-                      - AREA_NOT_COVERED
                       - IDENTIFIER_MISMATCH
                       - MULTIEVENT_SUBSCRIPTION_NOT_SUPPORTED
                       - SERVICE_NOT_APPLICABLE
                       - UNNECESSARY_IDENTIFIER
                       - UNSUPPORTED_IDENTIFIER
+                      - GEOFENCING_422_AREA_NOT_COVERED
+                      - GEOFENCING_422_INVALID_AREA
           examples:
-            GENERIC_422_AREA_NOT_COVERED:
-              value:
-                status: 422
-                code: AREA_NOT_COVERED
-                message: The specified area cannot be covered or is too small to be valid
             GENERIC_422_IDENTIFIER_MISMATCH:
               description: Inconsistency between device identifiers not pointing to the same device.
               value:
@@ -1366,6 +1365,20 @@ components:
                 status: 422
                 code: UNSUPPORTED_IDENTIFIER
                 message: The identifier provided is not supported.
+            GEOFENCING_422_AREA_NOT_COVERED:
+              summary: The area cannot be covered
+              description: The system is not able cover the requested area
+              value:
+                status: 422
+                code: GEOFENCING.AREA_NOT_COVERED
+                message: "Unable to cover the requested area"
+            GEOFENCING_422_INVALID_AREA:
+              summary: Invalid area
+              description: The requested area is too small to be supported by the system.
+              value:
+                status: 422
+                code: GEOFENCING.INVALID_AREA
+                message: "The requested area is too small"
     Generic429:
       description: Too Many Requests
       headers:

--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -1333,8 +1333,8 @@ components:
                       - SERVICE_NOT_APPLICABLE
                       - UNNECESSARY_IDENTIFIER
                       - UNSUPPORTED_IDENTIFIER
-                      - GEOFENCING_422_AREA_NOT_COVERED
-                      - GEOFENCING_422_INVALID_AREA
+                      - GEOFENCING.AREA_NOT_COVERED
+                      - GEOFENCING.INVALID_AREA
           examples:
             GENERIC_422_IDENTIFIER_MISMATCH:
               description: Inconsistency between device identifiers not pointing to the same device.

--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -737,8 +737,10 @@ components:
               $ref: "#/components/schemas/Point"
             radius:
               type: integer
-              description: Expected accuracy for the subscription event of device location in m, from location (radius).
-              minimum: 2000
+              description: |
+                Expected accuracy for the subscription event of device location in m, from location (radius).
+                Note: The area surface could be restricted locally depending on regulations. Implementations may enforce a larger minimum radius (e.g. 1000 meters).
+              minimum: 1
               maximum: 200000
           required:
             - center

--- a/code/API_definitions/location-verification.yaml
+++ b/code/API_definitions/location-verification.yaml
@@ -258,7 +258,7 @@ components:
             radius:
               type: integer
               description: |
-                Expected accuracy for the verification in meters, from center.
+                Expected accuracy for the verification, in meters from `center`.
                 Note: The area surface could be restricted locally depending on regulations. Implementations may enforce a larger minimum radius (e.g. 1000 meters).
               minimum: 1
               maximum: 200000

--- a/code/API_definitions/location-verification.yaml
+++ b/code/API_definitions/location-verification.yaml
@@ -566,8 +566,58 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 422
+                  code:
+                    enum:
+                      - AREA_NOT_COVERED
+                      - IDENTIFIER_MISMATCH
+                      - SERVICE_NOT_APPLICABLE
+                      - MISSING_IDENTIFIER
+                      - UNSUPPORTED_IDENTIFIER
+                      - UNNECESSARY_IDENTIFIER
+                      - LOCATION_VERIFICATION.UNABLE_TO_FULFILL_MAX_AGE
           examples:
+            GENERIC_422_AREA_NOT_COVERED:
+              value:
+                status: 422
+                code: AREA_NOT_COVERED
+                message: The specified area cannot be covered or is too small to be valid
+            GENERIC_422_IDENTIFIER_MISMATCH:
+              description: Inconsistency between identifiers not pointing to the same device
+              value:
+                status: 422
+                code: IDENTIFIER_MISMATCH
+                message: Provided identifiers are not consistent.
+            GENERIC_422_SERVICE_NOT_APPLICABLE:
+              description: Service not applicable for the provided identifier
+              value:
+                status: 422
+                code: SERVICE_NOT_APPLICABLE
+                message: The service is not available for the provided identifier.
+            GENERIC_422_MISSING_IDENTIFIER:
+              description: An identifier is not included in the request and the device or phone number identification cannot be derived from the 3-legged access token
+              value:
+                status: 422
+                code: MISSING_IDENTIFIER
+                message: The device cannot be identified.
+            GENERIC_422_UNSUPPORTED_IDENTIFIER:
+              description: None of the provided identifiers is supported by the implementation
+              value:
+                status: 422
+                code: UNSUPPORTED_IDENTIFIER
+                message: The identifier provided is not supported.
+            GENERIC_422_UNNECESSARY_IDENTIFIER:
+              description: An explicit identifier is provided when a device or phone number has already been identified from the access token
+              value:
+                status: 422
+                code: UNNECESSARY_IDENTIFIER
+                message: The device is already identified by the access token.
             LOCATION_VERIFICATION_422_UNABLE_TO_FULFILL_MAX_AGE:
               summary: Unable to fulfill maxAge
               description: The system is not able to provide the fresh location required by the client
@@ -575,46 +625,6 @@ components:
                 status: 422
                 code: LOCATION_VERIFICATION.UNABLE_TO_FULFILL_MAX_AGE
                 message: "Unable to provide expected freshness for location"
-            GENERIC_422_AREA_NOT_COVERED:
-              value:
-                status: 422
-                code: AREA_NOT_COVERED
-                message: The specified area cannot be covered or is too small to be valid
-            GENERIC_422_UNPROCESSABLE_ENTITY:
-              summary: Unprocessable entity
-              description: The request was well-formed but was unable to be processed due to semantic errors or not applicable values. This is the generic error code for 422 responses.
-              value:
-                status: 422
-                code: UNPROCESSABLE_ENTITY
-                message: "Value not acceptable: ..."
-            GENERIC_422_DEVICE_NOT_APPLICABLE:
-              summary: Service not applicable to the device
-              description: The provided device is not compatible with the requested operation, according to the service provider rules.
-              value:
-                status: 422
-                code: DEVICE_NOT_APPLICABLE
-                message: "The device is not applicable for the requested operation"
-            GENERIC_422_DEVICE_IDENTIFIERS_MISMATCH:
-              summary: Device identifiers mismatch
-              description: Several device identifiers are provided but do not match the same device
-              value:
-                status: 422
-                code: DEVICE_IDENTIFIERS_MISMATCH
-                message: "The provided device identifiers do not match the same device"
-            GENERIC_422_UNSUPPORTED_DEVICE_IDENTIFIERS:
-              summary: None of the provided device identifiers is supported by the implementation
-              description: Message may list the supported device identifiers
-              value:
-                status: 422
-                code: UNSUPPORTED_DEVICE_IDENTIFIERS
-                message: "Supported device identifiers are: ..."
-            GENERIC_422_UNIDENTIFIABLE_DEVICE:
-              summary: No identifier provided
-              description: No device identifier provided for the device to be located
-              value:
-                status: 422
-                code: UNIDENTIFIABLE_DEVICE
-                message: "A device must be provided"
 
     Generic429:
       description: Too Many Requests

--- a/code/API_definitions/location-verification.yaml
+++ b/code/API_definitions/location-verification.yaml
@@ -575,19 +575,15 @@ components:
                       - 422
                   code:
                     enum:
-                      - AREA_NOT_COVERED
                       - IDENTIFIER_MISMATCH
                       - SERVICE_NOT_APPLICABLE
                       - MISSING_IDENTIFIER
                       - UNSUPPORTED_IDENTIFIER
                       - UNNECESSARY_IDENTIFIER
+                      - LOCATION_VERIFICATION.AREA_NOT_COVERED
+                      - LOCATION_VERIFICATION.INVALID_AREA
                       - LOCATION_VERIFICATION.UNABLE_TO_FULFILL_MAX_AGE
           examples:
-            GENERIC_422_AREA_NOT_COVERED:
-              value:
-                status: 422
-                code: AREA_NOT_COVERED
-                message: The specified area cannot be covered or is too small to be valid
             GENERIC_422_IDENTIFIER_MISMATCH:
               description: Inconsistency between identifiers not pointing to the same device
               value:
@@ -618,6 +614,16 @@ components:
                 status: 422
                 code: UNNECESSARY_IDENTIFIER
                 message: The device is already identified by the access token.
+            LOCATION_VERIFICATION_422_AREA_NOT_COVERED:
+              value:
+                status: 422
+                code: LOCATION_VERIFICATION.AREA_NOT_COVERED
+                message: The requested area is not supported.
+            LOCATION_VERIFICATION_422_INVALID_AREA:
+              value:
+                status: 422
+                code: LOCATION_VERIFICATION.INVALID_AREA
+                message: The requested area is too small, too complex, etc.
             LOCATION_VERIFICATION_422_UNABLE_TO_FULFILL_MAX_AGE:
               summary: Unable to fulfill maxAge
               description: The system is not able to provide the fresh location required by the client
@@ -625,7 +631,6 @@ components:
                 status: 422
                 code: LOCATION_VERIFICATION.UNABLE_TO_FULFILL_MAX_AGE
                 message: "Unable to provide expected freshness for location"
-
     Generic429:
       description: Too Many Requests
       headers:

--- a/code/API_definitions/location-verification.yaml
+++ b/code/API_definitions/location-verification.yaml
@@ -8,14 +8,17 @@ info:
 
     API consumers are able to verify whether the location of certain user device is within the area specified. Currently the only area supported as input is a circle determined by a set of coordinates (latitude and longitude) and some expected accuracy (radius).
 
+    * If the provided area is out of the operator's coverage or it is not supported for any reason, an error `422 LOCATION_VERIFICATION.AREA_NOT_COVERED` will be returned.
+    * Legal restrictions regarding privacy, or other regulatory or implementation issues, may force the operator to set restrictions to the provided area, such as setting a minimum value to the accepted radius. In these cases, an error `422 LOCATION_VERIFICATION.INVALID_AREA` will be returned and the error message will refer to the reason of the limitation.
+
     The verification result depends on the network's ability and accuracy to locate the device at the requested area.
 
     * If the network's estimation of the device's location is fully contained within the requested area, the verification result is `TRUE`.
     * If the network's estimation of the device's location does not overlap with the requested area at all, the verification result is `FALSE`.
-    * If the network's estimation of the device's location partially overlaps with the requested area, or it fully contains the requested area (because it is larger), the result is 'PARTIAL'. In this case, a `match_rate` is included in the response, indicating an estimation of the likelihood of the match in percent.
+    * If the network's estimation of the device's location partially overlaps with the requested area, or it fully contains the requested area (because it is larger), the result is `PARTIAL`. In this case, a `match_rate` is included in the response, indicating an estimation of the likelihood of the match in percent.
     * Lastly, the network may not be able to locate the device. In this case, the verification result is `UNKNOWN`.
 
-    The client may optionally include a `maxAge` indication. If the location information known to the server is older than the specified `maxAge`, an error 422 with code LOCATION_VERIFICATION.UNABLE_TO_FULFILL_MAX_AGE is sent back.
+    The client may optionally include a `maxAge` indication. If the location information known to the server is older than the specified `maxAge`, an error with code `422 LOCATION_VERIFICATION.UNABLE_TO_FULFILL_MAX_AGE` is sent back.
 
     `lastLocationTime` will be always included in the success response unless there is no historical location information available for the device. In this case, `UNKNOWN` will be returned without `lastLocationTime`.
 
@@ -34,7 +37,7 @@ info:
 
      * **Max Age**: Maximum age of the location information which is accepted for the location verification (in seconds).
         * Absence of maxAge means "any age" is acceptable for the client. In other words, this is like maxAge=infinite. In this case the system will still return lastLocationTime, if available.
-        * maxAge=0 means a fresh calculation is requested by the client. If the system is not able to provide the fresh location, an error 422 with code LOCATION_VERIFICATION.UNABLE_TO_FULFILL_MAX_AGE is sent back.
+        * maxAge=0 means a fresh calculation is requested by the client. If the system is not able to provide the fresh location, an error with code `422 LOCATION_VERIFICATION.UNABLE_TO_FULFILL_MAX_AGE` is sent back.
 
 
     * **Verification**: Process triggered in the API server to confirm or contradict the expectation assumed by the API client about the device location.

--- a/code/API_definitions/location-verification.yaml
+++ b/code/API_definitions/location-verification.yaml
@@ -257,8 +257,10 @@ components:
               $ref: "#/components/schemas/Point"
             radius:
               type: integer
-              description: Expected accuracy for the verification in meters, from center
-              minimum: 2000
+              description: |
+                Expected accuracy for the verification in meters, from center.
+                Note: The area surface could be restricted locally depending on regulations. Implementations may enforce a larger minimum radius (e.g. 1000 meters).
+              minimum: 1
               maximum: 200000
           required:
             - center
@@ -573,6 +575,11 @@ components:
                 status: 422
                 code: LOCATION_VERIFICATION.UNABLE_TO_FULFILL_MAX_AGE
                 message: "Unable to provide expected freshness for location"
+            GENERIC_422_AREA_NOT_COVERED:
+              value:
+                status: 422
+                code: AREA_NOT_COVERED
+                message: The specified area cannot be covered or is too small to be valid
             GENERIC_422_UNPROCESSABLE_ENTITY:
               summary: Unprocessable entity
               description: The request was well-formed but was unable to be processed due to semantic errors or not applicable values. This is the generic error code for 422 responses.

--- a/code/API_definitions/location-verification.yaml
+++ b/code/API_definitions/location-verification.yaml
@@ -588,6 +588,8 @@ components:
                       - MISSING_IDENTIFIER
                       - UNSUPPORTED_IDENTIFIER
                       - UNNECESSARY_IDENTIFIER
+                      - LOCATION_VERIFICATION.AREA_NOT_COVERED
+                      - LOCATION_VERIFICATION.INVALID_AREA
                       - LOCATION_VERIFICATION.UNABLE_TO_FULFILL_MAX_AGE
           examples:
             GENERIC_422_IDENTIFIER_MISMATCH:
@@ -620,6 +622,20 @@ components:
                 status: 422
                 code: UNNECESSARY_IDENTIFIER
                 message: The device is already identified by the access token.
+            LOCATION_VERIFICATION_422_AREA_NOT_COVERED:
+              summary: The area cannot be covered
+              description: The system is not able cover the requested area
+              value:
+                status: 422
+                code: LOCATION_VERIFICATION.AREA_NOT_COVERED
+                message: "Unable to cover the requested area"
+            LOCATION_VERIFICATION_422_INVALID_AREA:
+              summary: Invalid area
+              description: The requested area is too small to be supported by the system.
+              value:
+                status: 422
+                code: LOCATION_VERIFICATION.INVALID_AREA
+                message: "The requested area is too small"
             LOCATION_VERIFICATION_422_UNABLE_TO_FULFILL_MAX_AGE:
               summary: Unable to fulfill maxAge
               description: The system is not able to provide the fresh location required by the client

--- a/code/Test_definitions/geofencing-subscriptions.feature
+++ b/code/Test_definitions/geofencing-subscriptions.feature
@@ -315,7 +315,7 @@ Feature: Camara Geofencing Subscriptions API, vwip - Operations on subscriptions
     When the HTTP "POST" request is sent
     Then the response status code is 422
     And the response property "$.status" is 422
-    And the response property "$.code" is "GEOFENCING.AREA_NOT_COVERED"
+    And the response property "$.code" is "GEOFENCING_SUBSCRIPTIONS.AREA_NOT_COVERED"
     And the response property "$.message" contains "Unable to cover the requested area"
 
   @geofencing_subscriptions_29_create_with_identifier_mismatch
@@ -360,5 +360,5 @@ Feature: Camara Geofencing Subscriptions API, vwip - Operations on subscriptions
     When the HTTP "POST" request is sent
     Then the response status code is 422
     And the response property "$.status" is 422
-    And the response property "$.code" is "GEOFENCING.INVALID_AREA"
+    And the response property "$.code" is "GEOFENCING_SUBSCRIPTIONS.INVALID_AREA"
     And the response property "$.message" contains "The requested area is too small"

--- a/code/Test_definitions/geofencing-subscriptions.feature
+++ b/code/Test_definitions/geofencing-subscriptions.feature
@@ -309,14 +309,14 @@ Feature: Camara Geofencing Subscriptions API, v0.3.0 - Operations on subscriptio
     And the response property "$.code" is "NOT_FOUND"
     And the response property "$.message" contains a user friendly text
 
-  @geofencing_subscriptions_28_create_with_invalid_area
+  @geofencing_subscriptions_28_create_with_an_unsupported_area
   Scenario: Create subscription with an invalid area
     Given the request body property "$.area" is set to an unsupported or invalid area
     When the HTTP "POST" request is sent
     Then the response status code is 422
     And the response property "$.status" is 422
-    And the response property "$.code" is "AREA_NOT_COVERED"
-    And the response property "$.message" contains "The specified area cannot be covered or is invalid."
+    And the response property "$.code" is "GEOFENCING.AREA_NOT_COVERED"
+    And the response property "$.message" contains "Unable to cover the requested area"
 
   @geofencing_subscriptions_29_create_with_identifier_mismatch
   Scenario: Create subscription with identifier mismatch
@@ -353,3 +353,12 @@ Feature: Camara Geofencing Subscriptions API, v0.3.0 - Operations on subscriptio
     And the response property "$.status" is 422
     And the response property "$.code" is "UNSUPPORTED_IDENTIFIER"
     And the response property "$.message" contains "The identifier provided is not supported."
+
+  @geofencing_subscriptions_33_create_with_an_invalid_area
+  Scenario: Create subscription with an invalid area
+    Given the request body property "$.area" is set with an too small area-size
+    When the HTTP "POST" request is sent
+    Then the response status code is 422
+    And the response property "$.status" is 422
+    And the response property "$.code" is "GEOFENCING.INVALID_AREA"
+    And the response property "$.message" contains "The requested area is too small"

--- a/code/Test_definitions/geofencing-subscriptions.feature
+++ b/code/Test_definitions/geofencing-subscriptions.feature
@@ -1,11 +1,11 @@
 @Geofencing 
-Feature: Camara Geofencing Subscriptions API, v0.3.0 - Operations on subscriptions 
+Feature: Camara Geofencing Subscriptions API, vwip - Operations on subscriptions
 
 # Input to be provided by the implementation to the tests
-# References to OAS spec schemas refer to schemas specified in geofencing-subscriptions.yaml, version v0.3.0
+# References to OAS spec schemas refer to schemas specified in geofencing-subscriptions.yaml, version vwip
 
   Background: Common Geofencing Subscriptions setup
-    Given the resource "{apiroot}/geofencing-subscriptions/v0.3/" as geofencing base-url                                                           
+    Given the resource "{apiroot}/geofencing-subscriptions/vwip/" as geofencing base-url
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" is set to a UUID value
 


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* enhancement/feature


#### What this PR does / why we need it:
This PR decreses the minimum of a circle-area radius to "1".
The provider of the API can restrict then the minimum and respond with HTTP-422 if the size of the area is to small and cannot be covered.



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #282 

#### Special notes for reviewers:



#### Changelog input

```
 release-note
* [location-verification / geofencing]: decrease radius minimum to "1" for circle-area
```

