### PR TITLE
Add quote-marks for "lastLocationTime" and "subscriptionExpireTime" - examples

### DIFF
--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -412,7 +412,7 @@ components:
         subscriptionExpireTime:
           type: string
           format: date-time
-          example: 2023-01-17T13:18:23.682Z
+          example: "2023-01-17T13:18:23.682Z"
           description: The subscription expiration time (in date-time format) requested by the API consumer.
         subscriptionMaxEvents:
           type: integer
@@ -1320,7 +1320,7 @@ components:
               radius: 2000
           initialEvent: true
           subscriptionMaxEvents: 10
-          subscriptionExpireTime: 2024-03-22T05:40:58.469Z
+          subscriptionExpireTime: "2024-03-22T05:40:58.469Z"
     CIRCLE_AREA_ENTERED:
       description: The cloud event when a geofence area was entered.
       value:

--- a/code/API_definitions/location-retrieval.yaml
+++ b/code/API_definitions/location-retrieval.yaml
@@ -291,9 +291,7 @@ components:
         - area
       properties:
         lastLocationTime:
-          description: Last date and time when the device was localized. It must follow RFC 3339 and must have time zone. Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z)
-          type: string
-          format: date-time
+          $ref: "#/components/schemas/LastLocationTime"
         area:
           $ref: '#/components/schemas/Area'
 
@@ -370,6 +368,12 @@ components:
       example:
         latitude: 50.735851
         longitude: 7.10066
+
+    LastLocationTime:
+      description: Last date and time when the device was localized. It must follow RFC 3339 and must have time zone. Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z)
+      format: date-time
+      type: string
+      example: "2023-09-07T10:40:52Z"
 
     Latitude:
       description: Latitude component of a location
@@ -601,7 +605,7 @@ components:
       summary: circle-based device location retrieval
       description: The device is localized within a circle with a center at the specified coordinates and a radius of 800 meters.
       value:
-        lastLocationTime: 2023-10-17T13:18:23.682Z
+        lastLocationTime: "2023-10-17T13:18:23.682Z"
         area:
           areaType: CIRCLE
           center:
@@ -612,7 +616,7 @@ components:
       summary: polygon-based device location retrieval
       description: The device is localized within a polygon delimited by the provided coordinates.
       value:
-        lastLocationTime: 2023-10-17T13:18:23.682Z
+        lastLocationTime: "2023-10-17T13:18:23.682Z"
         area:
           areaType: POLYGON
           boundary:

--- a/code/API_definitions/location-verification.yaml
+++ b/code/API_definitions/location-verification.yaml
@@ -169,13 +169,13 @@ paths:
                   description: The network locates the device within the requested area
                   value:
                     verificationResult: "TRUE"
-                    lastLocationTime: 2023-09-07T10:40:52Z
+                    lastLocationTime: "2023-09-07T10:40:52Z"
                 VERIFICATION_FALSE:
                   summary: No match
                   description: The requested area does not match the area where the network locates the device
                   value:
                     verificationResult: "FALSE"
-                    lastLocationTime: 2023-09-07T10:40:52Z
+                    lastLocationTime: "2023-09-07T10:40:52Z"
                 VERIFICATION_UNKNOWN:
                   summary: Unknown
                   description: The network cannot locate the device
@@ -187,7 +187,7 @@ paths:
                   value:
                     verificationResult: "PARTIAL"
                     matchRate: 74
-                    lastLocationTime: 2023-09-07T10:40:52Z
+                    lastLocationTime: "2023-09-07T10:40:52Z"
         "400":
           $ref: "#/components/responses/Generic400"
         "401":


### PR DESCRIPTION



#### What type of PR is this?

Add one of the following kinds:
* correction


#### What this PR does / why we need it:
This small PR adds quote-marks for date-time examples of the fields `subscriptionExpireTime` and `lastLocationTime`



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #286 

#### Changelog input

```
 release-note
+ Add quote-marks for "lastLocationTime" and "subscriptionExpireTime" - examples
```

