### PR TITLE
Add MultiSIM section to info.description

### DIFF
--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -81,7 +81,7 @@ info:
 
     - Using preferably the authorisation code flow to obtain an access token, which will automatically identify the intended device.
     - Identifying the intended device from a unique identifier for that device, such as its source IP address and port.
-    - Check with the SIM provider whether a unique "secondary" phone number is already associated with each device and use the secondary phone number to identify the intended device if available.
+    - Check with the API provider whether a unique "secondary" phone number is already associated with each device and use the secondary phone number to identify the intended device if available.
 
     # Further info and support
 

--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -75,14 +75,14 @@ info:
 
     - rejecting the subscription with an error indicating that that phone number is not supported for this API, or
     - generating events for a single device in the multi-SIM group, if one of the devices is considered linked to the main SIM and this concept is supported by the operator, or
-    - generating events for of all the SIMs associated to the requested phone number. 
-    
+    - generating events for of all the SIMs associated to the requested phone number.
+
     Possible solutions to make the scenario more deterministic include:
 
     - Using preferably the authorisation code flow to obtain an access token, which will automatically identify the intended device.
     - Identifying the intended device from a unique identifier for that device, such as its source IP address and port.
     - Check with the SIM provider whether a unique "secondary" phone number is already associated with each device and use the secondary phone number to identify the intended device if available.
-  
+
     # Further info and support
 
     (FAQs will be added in a later version of the documentation)

--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -69,6 +69,20 @@ info:
 
     It is important to remark that in cases where personal user data is processed by the API, and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of 3-legged access tokens becomes mandatory. This measure ensures that the API remains in strict compliance with user privacy preferences and regulatory obligations, upholding the principles of transparency and user-centric data control.
 
+    # Multi-SIM scenario handling
+
+    In multi-SIM scenarios, where more than one mobile device is associated with the phone number given as input in the API call (e.g. a smartphone with an associated smartwatch), it might not be possible to uniquely identify the device whose location is to be verified. Check with the API provider what is the expected behaviour when a phone number belonging to a multi-SIM group is used as the device identifier, as the API may behave:
+
+    - rejecting the subscription with an error indicating that that phone number is not supported for this API, or
+    - generating events for a single device in the multi-SIM group, if one of the devices is considered linked to the main SIM and this concept is supported by the operator, or
+    - generating events for of all the SIMs associated to the requested phone number. 
+    
+    Possible solutions to make the scenario more deterministic include:
+
+    - Using preferably the authorisation code flow to obtain an access token, which will automatically identify the intended device.
+    - Identifying the intended device from a unique identifier for that device, such as its source IP address and port.
+    - Check with the SIM provider whether a unique "secondary" phone number is already associated with each device and use the secondary phone number to identify the intended device if available.
+  
     # Further info and support
 
     (FAQs will be added in a later version of the documentation)

--- a/code/API_definitions/location-retrieval.yaml
+++ b/code/API_definitions/location-retrieval.yaml
@@ -96,7 +96,7 @@ info:
 
     - Using preferably the authorisation code flow to obtain an access token, which will automatically identify the intended device.
     - Identifying the intended device from a unique identifier for that device, such as its source IP address and port.
-    - Check with the SIM provider whether a unique "secondary" phone number is already associated with each device and use the secondary phone number to identify the intended device if available.
+    - Check with the API provider whether a unique "secondary" phone number is already associated with each device and use the secondary phone number to identify the intended device if available.
 
     # Further info and support
 

--- a/code/API_definitions/location-retrieval.yaml
+++ b/code/API_definitions/location-retrieval.yaml
@@ -90,13 +90,13 @@ info:
 
     - an error indicating that that phone number is not supported for this API, or
     - the location of a single device in the multi-SIM group, if one of the devices is considered linked to the main SIM and this concept is supported by the operator, or
-    - a location value that combines the location of all the SIMs associated to the requested phone number. 
-    
+    - a location value that combines the location of all the SIMs associated to the requested phone number.
+
     Possible solutions to make the scenario more deterministic include:
 
     - Using preferably the authorisation code flow to obtain an access token, which will automatically identify the intended device.
     - Identifying the intended device from a unique identifier for that device, such as its source IP address and port.
-    - Check with the SIM provider whether a unique "secondary" phone number is already associated with each device and use the secondary phone number to identify the intended device if available.  
+    - Check with the SIM provider whether a unique "secondary" phone number is already associated with each device and use the secondary phone number to identify the intended device if available.
 
     # Further info and support
 

--- a/code/API_definitions/location-retrieval.yaml
+++ b/code/API_definitions/location-retrieval.yaml
@@ -84,6 +84,20 @@ info:
 
     - If the subject can be identified from the access token and the optional `device` object is also included in the request, then the server will return an error with the `422 UNNECESSARY_IDENTIFIER` error code. This will be the case even if the same device is identified by these two methods, as the server is unable to make this comparison.
 
+    # Multi-SIM scenario handling
+
+    In multi-SIM scenarios, where more than one mobile device is associated with the phone number given as input in the API call (e.g. a smartphone with an associated smartwatch), it might not be possible to uniquely identify the device whose location is to be verified. Check with the API provider what is the expected behaviour when a phone number belonging to a multi-SIM group is used as the device identifier, as the API may response with:
+
+    - an error indicating that that phone number is not supported for this API, or
+    - the location of a single device in the multi-SIM group, if one of the devices is considered linked to the main SIM and this concept is supported by the operator, or
+    - a location value that combines the location of all the SIMs associated to the requested phone number. 
+    
+    Possible solutions to make the scenario more deterministic include:
+
+    - Using preferably the authorisation code flow to obtain an access token, which will automatically identify the intended device.
+    - Identifying the intended device from a unique identifier for that device, such as its source IP address and port.
+    - Check with the SIM provider whether a unique "secondary" phone number is already associated with each device and use the secondary phone number to identify the intended device if available.  
+
     # Further info and support
 
     (FAQs will be added in a later version of the documentation)

--- a/code/API_definitions/location-verification.yaml
+++ b/code/API_definitions/location-verification.yaml
@@ -79,7 +79,7 @@ info:
 
     - Using preferably the authorisation code flow to obtain an access token, which will automatically identify the intended device.
     - Identifying the intended device from a unique identifier for that device, such as its source IP address and port.
-    - Check with the SIM provider whether a unique "secondary" phone number is already associated with each device and use the secondary phone number to identify the intended device if available.
+    - Check with the API provider whether a unique "secondary" phone number is already associated with each device and use the secondary phone number to identify the intended device if available.
 
     # Further info and support
 

--- a/code/API_definitions/location-verification.yaml
+++ b/code/API_definitions/location-verification.yaml
@@ -67,6 +67,20 @@ info:
 
     - If the subject can be identified from the access token and the optional `device` object is also included in the request, then the server will return an error with the `422 UNNECESSARY_IDENTIFIER` error code. This will be the case even if the same device is identified by these two methods, as the server is unable to make this comparison.
 
+    # Multi-SIM scenario handling
+
+    In multi-SIM scenarios, where more than one mobile device is associated with the phone number given as input in the API call (e.g. a smartphone with an associated smartwatch), it might not be possible to uniquely identify the device whose location is to be verified. Check with the API provider what is the expected behaviour when a phone number belonging to a multi-SIM group is used as the device identifier, as the API may response with:
+
+    - an error indicating that that phone number is not supported for this API, or
+    - the verification for a single device in the multi-SIM group, if one of the devices is considered linked to the main SIM and this concept is supported by the operator, or
+    - a verification value that combines the location verification of all the SIMs associated to the requested phone number. 
+    
+    Possible solutions to make the scenario more deterministic include:
+
+    - Using preferably the authorisation code flow to obtain an access token, which will automatically identify the intended device.
+    - Identifying the intended device from a unique identifier for that device, such as its source IP address and port.
+    - Check with the SIM provider whether a unique "secondary" phone number is already associated with each device and use the secondary phone number to identify the intended device if available.  
+    
     # Further info and support
 
     (FAQs will be added in a later version of the documentation)

--- a/code/API_definitions/location-verification.yaml
+++ b/code/API_definitions/location-verification.yaml
@@ -73,14 +73,14 @@ info:
 
     - an error indicating that that phone number is not supported for this API, or
     - the verification for a single device in the multi-SIM group, if one of the devices is considered linked to the main SIM and this concept is supported by the operator, or
-    - a verification value that combines the location verification of all the SIMs associated to the requested phone number. 
-    
+    - a verification value that combines the location verification of all the SIMs associated to the requested phone number.
+
     Possible solutions to make the scenario more deterministic include:
 
     - Using preferably the authorisation code flow to obtain an access token, which will automatically identify the intended device.
     - Identifying the intended device from a unique identifier for that device, such as its source IP address and port.
-    - Check with the SIM provider whether a unique "secondary" phone number is already associated with each device and use the secondary phone number to identify the intended device if available.  
-    
+    - Check with the SIM provider whether a unique "secondary" phone number is already associated with each device and use the secondary phone number to identify the intended device if available.
+
     # Further info and support
 
     (FAQs will be added in a later version of the documentation)


### PR DESCRIPTION
#### What type of PR is this?

* documentation

#### What this PR does / why we need it:

Current documentation omits the potential problem with phone numbers identifying a MultiSIM group. As there is no a single behaviour agreed in CAMARA yet, the proposed enhancement presents the problem and gives some hints to mitigate it


#### Which issue(s) this PR fixes:

Fixes #257

#### Special notes for reviewers:



#### Changelog input

```
* Adding section for "Multi-SIM scenario handling" in info.description
```
