### PR TITLE
Location verification align error tests

### DIFF
--- a/code/API_definitions/location-verification.yaml
+++ b/code/API_definitions/location-verification.yaml
@@ -205,8 +205,6 @@ paths:
           $ref: "#/components/responses/Generic404"
         "422":
           $ref: "#/components/responses/VerifyLocationUnprocessableEntity422"
-        "429":
-          $ref: "#/components/responses/Generic429"
       security:
         - openId:
             - location-verification:verify
@@ -659,36 +657,3 @@ components:
                 status: 422
                 code: LOCATION_VERIFICATION.UNABLE_TO_FULFILL_MAX_AGE
                 message: "Unable to provide expected freshness for location"
-
-    Generic429:
-      description: Too Many Requests
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 429
-                  code:
-                    enum:
-                      - QUOTA_EXCEEDED
-                      - TOO_MANY_REQUESTS
-          examples:
-            GENERIC_429_QUOTA_EXCEEDED:
-              description: Request is rejected due to exceeding a business quota limit
-              value:
-                status: 429
-                code: QUOTA_EXCEEDED
-                message: Out of resource quota.
-            GENERIC_429_TOO_MANY_REQUESTS:
-              description: Access to the API has been temporarily blocked due to rate or spike arrest limits being reached
-              value:
-                status: 429
-                code: TOO_MANY_REQUESTS
-                message: Rate limit reached.

--- a/code/Test_definitions/location-verification.feature
+++ b/code/Test_definitions/location-verification.feature
@@ -13,7 +13,6 @@ Feature: CAMARA Device location verification API, vwip - Operation verifyLocatio
 
   Background: Common verifyLocation setup
     Given the resource "/location-verification/vwip/verify"
-
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" is set to a UUID value
@@ -283,4 +282,16 @@ Feature: CAMARA Device location verification API, vwip - Operation verifyLocatio
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.message" contains a user friendly text
+
+  # Generic 403 error
+
+  @location_verification_403_no_authorization_header
+  Scenario: No Authorization header
+    Given the header "Authorization" is set to an access token without the required scope
+    And the request body is set to a valid request body
+    When the HTTP "POST" request is sent
+    Then the response status code is 403
+    And the response property "$.status" is 403
+    And the response property "$.code" is "PERMISSION_DENIED"
     And the response property "$.message" contains a user friendly text


### PR DESCRIPTION
#### What type of PR is this?

* tests

#### What this PR does / why we need it:

* Adds a test scenario to cover 403 PERMISSION_DENIED
* Adds test scenarios to cover specific 422 errors
* Adapts scenario to return UNKNOWN
* Removes 429 errors as explicitly documented in the OAS, as there is no specific logic for this API regarding those errors-


#### Which issue(s) this PR fixes:

Fixes #304 

#### Special notes for reviewers:

404 NOT_FOUND is exceptionally kept in the spec even if there is no test for it 

#### Changelog input

```
Test scenarios aligned with errors in spec

```

#### Additional documentation 

This section can be blank.



```
docs

```
