### PR TITLE
[geofencing-subscriptions]: Add "MISSING_IDENTIFIER" to the 422-error codes

### DIFF
--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -1345,6 +1345,7 @@ components:
                   code:
                     enum:
                       - IDENTIFIER_MISMATCH
+                      - MISSING_IDENTIFIER
                       - MULTIEVENT_SUBSCRIPTION_NOT_SUPPORTED
                       - SERVICE_NOT_APPLICABLE
                       - UNNECESSARY_IDENTIFIER
@@ -1364,6 +1365,12 @@ components:
                 status: 422
                 code: SERVICE_NOT_APPLICABLE
                 message: The service is not available for the provided identifier.
+            GENERIC_422_MISSING_IDENTIFIER:
+              description: An identifier is not included in the request and the device or phone number identification cannot be derived from the 3-legged access token
+              value:
+                status: 422
+                code: MISSING_IDENTIFIER
+                message: The device cannot be identified.
             GENERIC_422_MULTIEVENT_SUBSCRIPTION_NOT_SUPPORTED:
               value:
                 status: 422

--- a/code/Test_definitions/geofencing-subscriptions.feature
+++ b/code/Test_definitions/geofencing-subscriptions.feature
@@ -362,3 +362,13 @@ Feature: Camara Geofencing Subscriptions API, vwip - Operations on subscriptions
     And the response property "$.status" is 422
     And the response property "$.code" is "GEOFENCING_SUBSCRIPTIONS.INVALID_AREA"
     And the response property "$.message" contains "The requested area is too small"
+
+  @geofencing_subscriptions_33_missing_device
+  Scenario: Device not included and cannot be deduced from the access token
+    Given the header "Authorization" is set to a valid access token which does not identify a single device
+    And the request body property "$.device" is not included
+    When the HTTP "POST" request is sent
+    Then the response status code is 422
+    And the response property "$.status" is 422
+    And the response property "$.code" is "MISSING_IDENTIFIER"
+    And the response property "$.message" contains a user-friendly text


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* correction

#### What this PR does / why we need it:
Adds the `MISSING_IDENTIFIER` error in the 422 response.



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #300 


#### Changelog input

```
 release-note
* add "MISSING_IDENTIFIER" to the 422 response of geofencing-subscriptions
```
