### PR TITLE
Location Retrieval - Remove unnecessary error 400

### DIFF
--- a/code/API_definitions/location-retrieval.yaml
+++ b/code/API_definitions/location-retrieval.yaml
@@ -450,8 +450,6 @@ components:
                   code:
                     enum:
                       - INVALID_ARGUMENT
-                      - OUT_OF_RANGE
-                      - LOCATION_RETRIEVAL.MAXAGE_INVALID_ARGUMENT
           examples:
             GENERIC_400_INVALID_ARGUMENT:
               summary: Invalid argument
@@ -460,20 +458,6 @@ components:
                 status: 400
                 code: INVALID_ARGUMENT
                 message: Client specified an invalid argument, request body or query param.
-            GENERIC_400_OUT_OF_RANGE:
-              summary: Out of range
-              description: Out of Range. Specific Syntax Exception used when a given field has a pre-defined range or a invalid filter criteria combination is requested
-              value:
-                status: 400
-                code: OUT_OF_RANGE
-                message: Client specified an invalid range.
-            GENERIC_400_MAX_AGE_NOT_SATISFIABLE:
-              summary: Max age not satisfiable
-              description: maxAge required in the request cannot be satisfied. Specific error for this API
-              value:
-                status: 400
-                code: LOCATION_RETRIEVAL.MAXAGE_INVALID_ARGUMENT
-                message: "maxAge threshold cannot be satisfied"
     Generic401:
       description: Unauthorized
       headers:


### PR DESCRIPTION

#### What type of PR is this?

Add one of the following kinds:

* correction



#### What this PR does / why we need it:

Remove 400 OUT_OF_RANGE as no UC for it.
Remove 400 LOCATION_RETRIEVAL.MAXAGE_INVALID_ARGUMENT and keep only 422 UNABLE_TO_FULFILL_MAX_AGE


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #315 

#### Special notes for reviewers:



#### Changelog input

```
 release-note
- Remove 400 OUT_OF_RANGE as no UC for it.
- Remove 400 LOCATION_RETRIEVAL.MAXAGE_INVALID_ARGUMENT as redundant with 422 UNABLE_TO_FULFILL_MAX_AGE.

```

#### Additional documentation 

This section can be blank.



```
docs

```
