### PR TITLE
[geofencing-subscriptions]: Subscription types array items in response should be limited and reference to allowed SubscriptionEventType instead of any string

### DIFF
--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -593,9 +593,12 @@ components:
         types:
           description: |
             Camara Event types eligible to be delivered by this subscription.
+            Note: As of now we enforce to have only event type per subscription.
           type: array
+          minItems: 1
+          maxItems: 1
           items:
-            type: string
+            $ref: "#/components/schemas/SubscriptionEventType"
         config:
           $ref: "#/components/schemas/Config"
         id:


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction

#### What this PR does / why we need it:
This PR will reference add the reference to the `SubscriptionEventType`-component inside of the `types`-property of the geofencing-subscription response.



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #322 

#### Special notes for reviewers:
This PR is based on https://github.com/camaraproject/Commonalities/pull/432


#### Changelog input

```
 release-note
* [geofencing-subscriptions]: Subscription types array items in response should be limited and reference to allowed SubscriptionEventType instead of any string
```
