### PR TITLE
chore: migrate swagger editor links to CAMARA swagger-ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ In this context also some error response codes have been renamed or replaced to 
 * API definition with **inline documentation**:
 
   - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.2/code/API_definitions/location-verification.yaml&nocors)
-  - [View it on Swagger Editor](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.2/code/API_definitions/location-verification.yaml)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.2/code/API_definitions/location-verification.yaml)
   - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceLocation/blob/r2.2/code/API_definitions/location-verification.yaml)
 
 ### Added
@@ -76,7 +76,7 @@ In this context also some error response codes have been renamed or replaced to 
 * API definition with **inline documentation**:
 
   - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.2/code/API_definitions/location-retrieval.yaml&nocors)
-  - [View it on Swagger Editor](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.2/code/API_definitions/location-retrieval.yaml)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.2/code/API_definitions/location-retrieval.yaml)
   - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceLocation/blob/r2.2/code/API_definitions/location-retrieval.yaml)
 
 ### Added
@@ -111,7 +111,7 @@ In this context also some error response codes have been renamed or replaced to 
 * API definition with **inline documentation**:
 
   - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.2/code/API_definitions/geofencing-subscriptions.yaml&nocors)
-  - [View it on Swagger Editor](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.2/code/API_definitions/geofencing-subscriptions.yaml)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.2/code/API_definitions/geofencing-subscriptions.yaml)
   - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceLocation/blob/r2.2/code/API_definitions/geofencing-subscriptions.yaml)
 
 ### Added
@@ -163,7 +163,7 @@ In this context also some error response codes have been renamed or replaced to 
 * API definition with **inline documentation**:
 
   - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.1/code/API_definitions/location-verification.yaml&nocors)
-  - [View it on Swagger Editor](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.1/code/API_definitions/location-verification.yaml)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.1/code/API_definitions/location-verification.yaml)
   - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceLocation/blob/r2.1/code/API_definitions/location-verification.yaml)
 
 ### Breaking Changes
@@ -193,7 +193,7 @@ In this context also some error response codes have been renamed or replaced to 
 * API definition with **inline documentation**:
 
   - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.1/code/API_definitions/location-retrieval.yaml&nocors)
-  - [View it on Swagger Editor](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.1/code/API_definitions/location-retrieval.yaml)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.1/code/API_definitions/location-retrieval.yaml)
   - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceLocation/blob/r2.1/code/API_definitions/location-retrieval.yaml)
 
 ### Breaking Changes
@@ -227,7 +227,7 @@ In this context also some error response codes have been renamed or replaced to 
 * API definition with **inline documentation**:
 
   - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.1/code/API_definitions/geofencing-subscriptions.yaml&nocors)
-  - [View it on Swagger Editor](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.1/code/API_definitions/geofencing-subscriptions.yaml)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.1/code/API_definitions/geofencing-subscriptions.yaml)
   - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceLocation/blob/r2.1/code/API_definitions/geofencing-subscriptions.yaml)
 
 ### Breaking Changes
@@ -274,7 +274,7 @@ The API definition(s) are based on
 * API definition with **inline documentation**:
 
   - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r1.2/code/API_definitions/location-verification.yaml&nocors)
-  - [View it on Swagger Editor](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r1.2/code/API_definitions/location-verification.yaml)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r1.2/code/API_definitions/location-verification.yaml)
   - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceLocation/blob/r1.2/code/API_definitions/location-verification.yaml)
 
 ### Added
@@ -299,7 +299,7 @@ The API definition(s) are based on
 * API definition with **inline documentation**:
 
   - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r1.2/code/API_definitions/location-retrieval.yaml&nocors)
-  - [View it on Swagger Editor](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r1.2/code/API_definitions/location-retrieval.yaml)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r1.2/code/API_definitions/location-retrieval.yaml)
   - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceLocation/blob/r1.2/code/API_definitions/location-retrieval.yaml)
 
 ### Added
@@ -324,7 +324,7 @@ The API definition(s) are based on
 * API definition with **inline documentation**:
 
   - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r1.2/code/API_definitions/geofencing-subscriptions.yaml&nocors)
-  - [View it on Swagger Editor](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r1.2/code/API_definitions/geofencing-subscriptions.yaml)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r1.2/code/API_definitions/geofencing-subscriptions.yaml)
   - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceLocation/blob/r1.2/code/API_definitions/geofencing-subscriptions.yaml)
 
 ### Added
@@ -365,7 +365,7 @@ The API definition(s) are based on
 * API definition with **inline documentation**:
 
   - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r1.1/code/API_definitions/location-verification.yaml&nocors)
-  - [View it on Swagger Editor](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r1.1/code/API_definitions/location-verification.yaml)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r1.1/code/API_definitions/location-verification.yaml)
   - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceLocation/blob/r1.1/code/API_definitions/location-verification.yaml)
 
 ### Added
@@ -390,7 +390,7 @@ The API definition(s) are based on
 * API definition with **inline documentation**:
 
   - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r1.1/code/API_definitions/location-retrieval.yaml&nocors)
-  - [View it on Swagger Editor](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r1.1/code/API_definitions/location-retrieval.yaml)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r1.1/code/API_definitions/location-retrieval.yaml)
   - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceLocation/blob/r1.1/code/API_definitions/location-retrieval.yaml)
 
 ### Added
@@ -415,7 +415,7 @@ The API definition(s) are based on
 * API definition with **inline documentation**:
 
   - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r1.1/code/API_definitions/geofencing-subscriptions.yaml&nocors)
-  - [View it on Swagger Editor](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r1.1/code/API_definitions/geofencing-subscriptions.yaml)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r1.1/code/API_definitions/geofencing-subscriptions.yaml)
   - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceLocation/blob/r1.1/code/API_definitions/geofencing-subscriptions.yaml)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -34,17 +34,17 @@ Incubating API Repository to evolve and maintain the definitions and documentati
   - **location-verification v2.0.0** 
   [[YAML OAS]](https://github.com/camaraproject/DeviceLocation/blob/r2.2/code/API_definitions/location-verification.yaml)
   [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.2/code/API_definitions/location-verification.yaml&nocors)
-  [[View it on Swagger Editor]](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.2/code/API_definitions/location-verification.yaml)
+  [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.2/code/API_definitions/location-verification.yaml)
 
   - **location-retrieval v0.4.0** 
   [[YAML OAS]](https://github.com/camaraproject/DeviceLocation/blob/r2.2/code/API_definitions/location-retrieval.yaml)
   [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.2/code/API_definitions/location-retrieval.yaml&nocors)
-  [[View it on Swagger Editor]](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.2/code/API_definitions/location-retrieval.yaml)
+  [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.2/code/API_definitions/location-retrieval.yaml)
 
   - **geofencing-subscriptions v0.4.0**
   [[YAML OAS]](https://github.com/camaraproject/DeviceLocation/blob/r2.2/code/API_definitions/geofencing-subscriptions.yaml)
   [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.2/code/API_definitions/geofencing-subscriptions.yaml&nocors)
-  [[View it on Swagger Editor]](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.2/code/API_definitions/geofencing-subscriptions.yaml)
+  [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceLocation/r2.2/code/API_definitions/geofencing-subscriptions.yaml)
 
 ## Contributing
 


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* documentation
* subproject management


#### What this PR does / why we need it:
This pull request migrates swagger editor links to use the CAMARA project's dedicated swagger-ui instance for better reliability (original links to swagger.io were broken).

**Changes:**
* Replaced https://editor.swagger.io/ with https://camaraproject.github.io/swagger-ui/
* Replaced https://editor-next.swagger.io/ with https://camaraproject.github.io/swagger-ui/
* All API specification URLs remain unchanged - only the swagger editor host is updated 

**Benefits:**
Consistent CAMARA experience Centralized swagger-ui configuration Maintained compatibility with existing specification URLs




#### Which issue(s) this PR fixes:
Fixes #340 