### PR TITLE
Remove IDENTIFIER_MISMATCH error and associated test cases

### DIFF
--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -1549,7 +1549,7 @@ components:
               phoneNumber: "+12345678912"
               ipv4Address:
                 publicAddress: 123.234.1.2
-                publicPort: 1234              
+                publicPort: 1234     
             area:
               areaType: CIRCLE
               center:

--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -153,6 +153,8 @@ paths:
             examples:
               CIRCLE_AREA_ENTERED:
                 $ref: "#/components/examples/REQUEST_CIRCLE_AREA_ENTERED"
+              REQUEST_CIRCLE_AREA_ENTERED_MULTIPLE_IDENTIFIERS:
+                $ref: "#/components/examples/REQUEST_CIRCLE_AREA_ENTERED_MULTIPLE_IDENTIFIERS"
         required: true
       callbacks:
         notifications:
@@ -401,7 +403,7 @@ components:
           items:
             $ref: "#/components/schemas/SubscriptionEventType"
         config:
-          $ref: "#/components/schemas/Config"
+          $ref: "#/components/schemas/ConfigRequest"
       discriminator:
         propertyName: protocol
         mapping:
@@ -422,14 +424,8 @@ components:
       description: |
         Implementation-specific configuration parameters are needed by the subscription manager for acquiring events.
         In CAMARA we have predefined attributes like `subscriptionExpireTime`, `subscriptionMaxEvents`, `initialEvent`.
-        Specific event type attributes must be defined in `subscriptionDetail`.
-        Note: If a request is performed for several event types, all subscribed events will use the same `config` parameters.
       type: object
-      required:
-        - subscriptionDetail
       properties:
-        subscriptionDetail:
-          $ref: "#/components/schemas/SubscriptionDetail"
         subscriptionExpireTime:
           type: string
           format: date-time
@@ -448,6 +444,37 @@ components:
           description: |
             Set to `true` by API consumer if consumer wants to get an event as soon as the subscription is created and current situation reflects event request.
             Example: Consumer request area entered event. If consumer sets initialEvent to true and device is already in the geofence, an event is triggered.
+
+    ConfigRequest:
+      allOf:
+        - $ref: "#/components/schemas/Config"
+        - description: |
+            Implementation-specific configuration parameters are needed by the subscription manager for acquiring events.
+            In CAMARA we have predefined attributes like `subscriptionExpireTime`, `subscriptionMaxEvents`, `initialEvent`.
+            Specific event type attributes requested by the client must be defined in `subscriptionDetail`.
+            Note: If a request is performed for several event types, all subscribed events will use the same `config` parameters.
+          type: object
+          required:
+            - subscriptionDetail
+          properties:
+            subscriptionDetail:
+              $ref: "#/components/schemas/SubscriptionDetailRequest"
+
+    ConfigResponse:
+      allOf:
+        - $ref: "#/components/schemas/Config"
+        - description: |
+            Implementation-specific configuration parameters are needed by the subscription manager for acquiring events.
+            In CAMARA we have predefined attributes like `subscriptionExpireTime`, `subscriptionMaxEvents`, `initialEvent`.
+            Specific event type attributes granted by the implementation are included in `subscriptionDetail`.
+            Note: If a request is performed for several event types, all subscribed events will use the same `config` parameters.
+          type: object
+          required:
+            - subscriptionDetail
+          properties:
+            subscriptionDetail:
+              $ref: "#/components/schemas/SubscriptionDetailResponse"
+
 
     SinkCredential:
       type: object
@@ -548,12 +575,23 @@ components:
         - refreshToken
         - refreshTokenEndpoint
 
-    SubscriptionDetail:
+    SubscriptionDetailRequest:
       description: The detail of the requested event subscription.
       type: object
       properties:
         device:
           $ref: "#/components/schemas/Device"
+        area:
+          $ref: "#/components/schemas/Area"
+      required:
+        - area
+
+    SubscriptionDetailResponse:
+      description: The detail of the event subscription granted by the implementation.
+      type: object
+      properties:
+        device:
+          $ref: "#/components/schemas/DeviceResponse"
         area:
           $ref: "#/components/schemas/Area"
       required:
@@ -610,7 +648,7 @@ components:
           items:
             $ref: "#/components/schemas/SubscriptionEventType"
         config:
-          $ref: "#/components/schemas/Config"
+          $ref: "#/components/schemas/ConfigResponse"
         id:
           type: string
           description: The unique identifier of the subscription in the scope of the subscription manager. When this information is contained within an event notification, this concept SHALL be referred as `subscriptionId` as per [Commonalities Event Notification Model](https://github.com/camaraproject/Commonalities/blob/main/documentation/API-design-guidelines.md#122-event-notification).
@@ -679,8 +717,8 @@ components:
         * `phoneNumber`
         * `networkAccessIdentifier`
 
-        NOTE1: the API provider might support only a subset of these options. The API consumer can provide multiple identifiers to be compatible across different API providers. In this case the identifiers MUST belong to the same device
-        NOTE2: for the Commonalities release v0.4, we are enforcing that the networkAccessIdentifier is only part of the schema for future-proofing, and CAMARA does not currently allow its use. After the CAMARA meta-release work is concluded and the relevant issues are resolved, its use will need to be explicitly documented in the guidelines.
+        NOTE1: the API provider might support only a subset of these options. The API consumer can provide multiple identifiers to be compatible across different API providers. In this case the identifiers MUST belong to the same device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the response or event.
+        NOTE2: as for this Commonalities release, we are enforcing that the networkAccessIdentifier is only part of the schema for future-proofing, and CAMARA does not currently allow its use. After the CAMARA meta-release work is concluded and the relevant issues are resolved, its use will need to be explicitly documented in the guidelines.
       type: object
       properties:
         phoneNumber:
@@ -746,6 +784,14 @@ components:
       type: string
       format: ipv6
       example: 2001:db8:85a3:8d3:1319:8a2e:370:7344
+
+    DeviceResponse:
+      description: |
+        An identifier for the end-user equipment able to connect to the network that the response refers to. This parameter is only returned when the API consumer includes the `device` parameter in their request (i.e. they are using a two-legged access token), and is relevant when more than one device identifier is specified, as only one of those device identifiers is allowed in the response.
+        If the API consumer provides more than one device identifier in their request, the API provider must return a single identifier which is the one they are using to fulfil the request, even if the identifiers do not match the same device. API provider does not perform any logic to validate/correlate that the indicated device identifiers match the same device. No error should be returned if the identifiers are otherwise valid to prevent API consumers correlating different identifiers with a given end user.
+      allOf:
+        - $ref: "#/components/schemas/Device"
+        - maxProperties: 1
 
     Area:
       type: object
@@ -923,7 +969,7 @@ components:
         - subscriptionId
       properties:
         device:
-          $ref: "#/components/schemas/Device"
+          $ref: "#/components/schemas/DeviceResponse"
         area:
           $ref: "#/components/schemas/Area"
         subscriptionId:
@@ -941,7 +987,7 @@ components:
         - subscriptionId
       properties:
         device:
-          $ref: "#/components/schemas/Device"
+          $ref: "#/components/schemas/DeviceResponse"
         area:
           $ref: "#/components/schemas/Area"
         subscriptionId:
@@ -960,7 +1006,7 @@ components:
         - subscriptionId
       properties:
         device:
-          $ref: "#/components/schemas/Device"
+          $ref: "#/components/schemas/DeviceResponse"
         area:
           $ref: "#/components/schemas/Area"
         terminationReason:
@@ -1386,7 +1432,6 @@ components:
                       - 422
                   code:
                     enum:
-                      - IDENTIFIER_MISMATCH
                       - MISSING_IDENTIFIER
                       - MULTIEVENT_SUBSCRIPTION_NOT_SUPPORTED
                       - SERVICE_NOT_APPLICABLE
@@ -1395,12 +1440,6 @@ components:
                       - GEOFENCING_SUBSCRIPTIONS.AREA_NOT_COVERED
                       - GEOFENCING_SUBSCRIPTIONS.INVALID_AREA
           examples:
-            GENERIC_422_IDENTIFIER_MISMATCH:
-              description: Inconsistency between device identifiers not pointing to the same device.
-              value:
-                status: 422
-                code: IDENTIFIER_MISMATCH
-                message: Provided identifiers are not consistent.
             GENERIC_422_SERVICE_NOT_APPLICABLE:
               description: Service not applicable for the provided identifier
               value:
@@ -1488,6 +1527,29 @@ components:
           subscriptionDetail:
             device:
               phoneNumber: "+12345678912"
+            area:
+              areaType: CIRCLE
+              center:
+                latitude: 50.735851
+                longitude: 7.10066
+              radius: 2000
+          initialEvent: true
+          subscriptionMaxEvents: 10
+          subscriptionExpireTime: "2024-03-22T05:40:58.469Z"
+    REQUEST_CIRCLE_AREA_ENTERED_MULTIPLE_IDENTIFIERS:
+      description: A sample geofence for entering for a circle area.
+      value:
+        protocol: "HTTP"
+        sink: https://notificationSendServer12.supertelco.com
+        types:
+          - org.camaraproject.geofencing-subscriptions.v0.area-entered
+        config:
+          subscriptionDetail:
+            device:
+              phoneNumber: "+12345678912"
+              ipv4Address:
+                publicAddress: 123.234.1.2
+                publicPort: 1234              
             area:
               areaType: CIRCLE
               center:

--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -1549,7 +1549,7 @@ components:
               phoneNumber: "+12345678912"
               ipv4Address:
                 publicAddress: 123.234.1.2
-                publicPort: 1234     
+                publicPort: 1234
             area:
               areaType: CIRCLE
               center:

--- a/code/API_definitions/location-retrieval.yaml
+++ b/code/API_definitions/location-retrieval.yaml
@@ -157,7 +157,6 @@ paths:
                     phoneNumber: "+123456789"
                   maxAge: 120
                   maxSurface: 1000000
-
               INPUT_IP_ADDRESS_V4:
                 summary: IPv4 address without maxAge
                 description: Retrieve location for a device identified by an IPv4 address, without an indication for maxAge
@@ -171,7 +170,15 @@ paths:
                 description: The device has to be deducted from token
                 value:
                   maxAge: 120
-
+              INPUT_PHONE_NUMBER_IP_ADDRESS_V4:
+                summary: Both phone number and IPv4 address, without maxAge
+                description: Retrieve location for a device identified both by a phone number and an IPv4 address, without an indication for maxAge
+                value:
+                  device:
+                    phoneNumber: "+123456789"
+                    ipv4Address:
+                      publicAddress: 123.234.1.2
+                      publicPort: 1234    
       responses:
         '200':
           description: Location retrieval result
@@ -187,6 +194,8 @@ paths:
                   $ref: "#/components/examples/RETRIEVAL_CIRCLE"
                 LOCATION_POLYGON:
                   $ref: "#/components/examples/RETRIEVAL_POLYGON"
+                LOCATION_CIRCLE_WITH_DEVICE_DISAMBIGUATION:
+                  $ref: "#/components/examples/LOCATION_CIRCLE_WITH_DEVICE_DISAMBIGUATION"
         '400':
           $ref: '#/components/responses/Generic400'
         '401':
@@ -248,7 +257,7 @@ components:
         * `ipv6Address`
         * `phoneNumber`
         * `networkAccessIdentifier`
-        NOTE1: the network operator might support only a subset of these options. The API invoker can provide multiple identifiers to be compatible across different network operators. In this case the identifiers MUST belong to the same device.
+        NOTE1: the network operator might support only a subset of these options. The API invoker can provide multiple identifiers to be compatible across different network operators. In this case the identifiers MUST belong to the same device. . Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the response.
         NOTE2: as for this Commonalities release, we are enforcing that the networkAccessIdentifier is only part of the schema for future-proofing, and CAMARA does not currently allow its use. After the CAMARA meta-release work is concluded and the relevant issues are resolved, its use will need to be explicitly documented in the guidelines.
       type: object
       properties:
@@ -316,6 +325,14 @@ components:
       format: ipv6
       example: 2001:db8:85a3:8d3:1319:8a2e:370:7344
 
+    DeviceResponse:
+      description: |
+        An identifier for the end-user equipment able to connect to the network that the response refers to. This parameter is only returned when the API consumer includes the `device` parameter in their request (i.e. they are using a two-legged access token), and is relevant when more than one device identifier is specified, as only one of those device identifiers is allowed in the response.
+        If the API consumer provides more than one device identifier in their request, the API provider must return a single identifier which is the one they are using to fulfil the request, even if the identifiers do not match the same device. API provider does not perform any logic to validate/correlate that the indicated device identifiers match the same device. No error should be returned if the identifiers are otherwise valid to prevent API consumers correlating different identifiers with a given end user.
+      allOf:
+        - $ref: "#/components/schemas/Device"
+        - maxProperties: 1
+
     Location:
       type: object
       description: Device location
@@ -327,6 +344,8 @@ components:
           $ref: "#/components/schemas/LastLocationTime"
         area:
           $ref: '#/components/schemas/Area'
+        device:
+          $ref: "#/components/schemas/DeviceResponse"
 
     Area:
       description: Base schema for all areas
@@ -570,7 +589,6 @@ components:
                       - 422
                   code:
                     enum:
-                      - IDENTIFIER_MISMATCH
                       - SERVICE_NOT_APPLICABLE
                       - MISSING_IDENTIFIER
                       - UNSUPPORTED_IDENTIFIER
@@ -578,13 +596,6 @@ components:
                       - LOCATION_RETRIEVAL.UNABLE_TO_FULFILL_MAX_AGE
                       - LOCATION_RETRIEVAL.UNABLE_TO_FULFILL_MAX_SURFACE
           examples:
-            GENERIC_422_IDENTIFIER_MISMATCH:
-              summary: Identifier mismatch
-              description: Inconsistency between identifiers not pointing to the same device
-              value:
-                status: 422
-                code: IDENTIFIER_MISMATCH
-                message: Provided identifiers are not consistent.
             GENERIC_422_SERVICE_NOT_APPLICABLE:
               summary: Service not applicable
               description: Service not applicable for the provided identifier
@@ -657,3 +668,16 @@ components:
               longitude: 4.861125
             - latitude: 45.751442
               longitude: 4.859827
+    LOCATION_CIRCLE_WITH_DEVICE_DISAMBIGUATION:
+      summary: circle-based device location retrieval, returning the device identifier used by the implementation
+      description: The device is localized within a circle with a center at the specified coordinates and a radius of 800 meters. Several device identifiers were provided.
+      value:
+        lastLocationTime: "2023-10-17T13:18:23.682Z"
+        area:
+          areaType: CIRCLE
+          center:
+            latitude: 45.754114
+            longitude: 4.860374
+          radius: 800
+        device:
+          phoneNumber: "+123456789"

--- a/code/API_definitions/location-retrieval.yaml
+++ b/code/API_definitions/location-retrieval.yaml
@@ -178,7 +178,7 @@ paths:
                     phoneNumber: "+123456789"
                     ipv4Address:
                       publicAddress: 123.234.1.2
-                      publicPort: 1234    
+                      publicPort: 1234
       responses:
         '200':
           description: Location retrieval result

--- a/code/API_definitions/location-retrieval.yaml
+++ b/code/API_definitions/location-retrieval.yaml
@@ -194,8 +194,8 @@ paths:
                   $ref: "#/components/examples/RETRIEVAL_CIRCLE"
                 LOCATION_POLYGON:
                   $ref: "#/components/examples/RETRIEVAL_POLYGON"
-                LOCATION_CIRCLE_WITH_DEVICE_DISAMBIGUATION:
-                  $ref: "#/components/examples/LOCATION_CIRCLE_WITH_DEVICE_DISAMBIGUATION"
+                LOCATION_CIRCLE_WITH_DEVICE:
+                  $ref: "#/components/examples/LOCATION_CIRCLE_WITH_DEVICE"
         '400':
           $ref: '#/components/responses/Generic400'
         '401':
@@ -668,9 +668,9 @@ components:
               longitude: 4.861125
             - latitude: 45.751442
               longitude: 4.859827
-    LOCATION_CIRCLE_WITH_DEVICE_DISAMBIGUATION:
+    LOCATION_CIRCLE_WITH_DEVICE:
       summary: circle-based device location retrieval, returning the device identifier used by the implementation
-      description: The device is localized within a circle with a center at the specified coordinates and a radius of 800 meters. Several device identifiers were provided.
+      description: The device is localized within a circle with a center at the specified coordinates and a radius of 800 meters. Response when the request used a 2-legged access token with multiple device identifiers, or possibly only a single device identifier.
       value:
         lastLocationTime: "2023-10-17T13:18:23.682Z"
         area:

--- a/code/API_definitions/location-verification.yaml
+++ b/code/API_definitions/location-verification.yaml
@@ -156,6 +156,22 @@ paths:
                       latitude: 50.735851
                       longitude: 7.10066
                     radius: 50000
+              INPUT_PHONE_NUMBER_IP_ADDRESS_V4_CIRCLE:
+                summary: Both phone number and IPv4 address, circle and maxAge
+                description: Verify if device identified both by a phone number and an IPv4 address is within a circle, providing a maxAge
+                value:
+                  device:
+                    phoneNumber: "+123456789"
+                    ipv4Address:
+                      publicAddress: 123.234.1.2
+                      publicPort: 1234
+                  area:
+                    areaType: CIRCLE
+                    center:
+                      latitude: 50.735851
+                      longitude: 7.10066
+                    radius: 50000
+                  maxAge: 120
               INPUT_NO_DEVICE:
                 summary: Device not provided
                 description: The device has to be deducted from token
@@ -184,6 +200,14 @@ paths:
                   value:
                     verificationResult: "TRUE"
                     lastLocationTime: "2023-09-07T10:40:52Z"
+                VERIFICATION_TRUE_WITH_DEVICE_DISAMBIGUATION:
+                  summary: Match returning the device identifier used by the implementation
+                  description: The network locates the device within the requested area. Several device identifiers were provided.
+                  value:
+                    verificationResult: "TRUE"
+                    lastLocationTime: "2023-09-07T10:40:52Z"
+                    device:
+                      phoneNumber: "+123456789"
                 VERIFICATION_FALSE:
                   summary: No match
                   description: The requested area does not match the area where the network locates the device
@@ -340,6 +364,8 @@ components:
           $ref: "#/components/schemas/VerificationResult"
         matchRate:
           $ref: "#/components/schemas/MatchRate"
+        device:
+          $ref: "#/components/schemas/DeviceResponse"
 
     Device:
       description: |
@@ -352,7 +378,7 @@ components:
         * `phoneNumber`
         * `networkAccessIdentifier`
 
-        NOTE1: the API provider might support only a subset of these options. The API consumer can provide multiple identifiers to be compatible across different API providers. In this case the identifiers MUST belong to the same device
+        NOTE1: the API provider might support only a subset of these options. The API consumer can provide multiple identifiers to be compatible across different API providers. In this case the identifiers MUST belong to the same device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the response.
         NOTE2: as for this Commonalities release, we are enforcing that the networkAccessIdentifier is only part of the schema for future-proofing, and CAMARA does not currently allow its use. After the CAMARA meta-release work is concluded and the relevant issues are resolved, its use will need to be explicitly documented in the guidelines.
       type: object
       properties:
@@ -419,6 +445,14 @@ components:
       type: string
       format: ipv6
       example: 2001:db8:85a3:8d3:1319:8a2e:370:7344
+
+    DeviceResponse:
+      description: |
+        An identifier for the end-user equipment able to connect to the network that the response refers to. This parameter is only returned when the API consumer includes the `device` parameter in their request (i.e. they are using a two-legged access token), and is relevant when more than one device identifier is specified, as only one of those device identifiers is allowed in the response.
+        If the API consumer provides more than one device identifier in their request, the API provider must return a single identifier which is the one they are using to fulfil the request, even if the identifiers do not match the same device. API provider does not perform any logic to validate/correlate that the indicated device identifiers match the same device. No error should be returned if the identifiers are otherwise valid to prevent API consumers correlating different identifiers with a given end user.
+      allOf:
+        - $ref: "#/components/schemas/Device"
+        - maxProperties: 1
 
     MaxAge:
       description: The maximum age (in seconds) for the location known by the implementation, which is accepted for the verification. Absence of maxAge means "any age" and maxAge=0 means a fresh calculation.
@@ -599,7 +633,6 @@ components:
                       - 422
                   code:
                     enum:
-                      - IDENTIFIER_MISMATCH
                       - SERVICE_NOT_APPLICABLE
                       - MISSING_IDENTIFIER
                       - UNSUPPORTED_IDENTIFIER
@@ -608,12 +641,6 @@ components:
                       - LOCATION_VERIFICATION.INVALID_AREA
                       - LOCATION_VERIFICATION.UNABLE_TO_FULFILL_MAX_AGE
           examples:
-            GENERIC_422_IDENTIFIER_MISMATCH:
-              description: Inconsistency between identifiers not pointing to the same device
-              value:
-                status: 422
-                code: IDENTIFIER_MISMATCH
-                message: Provided identifiers are not consistent.
             GENERIC_422_SERVICE_NOT_APPLICABLE:
               description: Service not applicable for the provided identifier
               value:

--- a/code/API_definitions/location-verification.yaml
+++ b/code/API_definitions/location-verification.yaml
@@ -198,9 +198,9 @@ paths:
                   value:
                     verificationResult: "TRUE"
                     lastLocationTime: "2023-09-07T10:40:52Z"
-                VERIFICATION_TRUE_WITH_DEVICE_DISAMBIGUATION:
+                VERIFICATION_TRUE_WITH_DEVICE:
                   summary: Match returning the device identifier used by the implementation
-                  description: The network locates the device within the requested area. Several device identifiers were provided.
+                  description: The network locates the device within the requested area. Response when the request used a 2-legged access token with multiple device identifiers, or possibly only a single device identifier
                   value:
                     verificationResult: "TRUE"
                     lastLocationTime: "2023-09-07T10:40:52Z"

--- a/code/Test_definitions/geofencing-subscriptions.feature
+++ b/code/Test_definitions/geofencing-subscriptions.feature
@@ -326,14 +326,7 @@ Feature: Camara Geofencing Subscriptions API, vwip - Operations on subscriptions
     And the response property "$.code" is "GEOFENCING_SUBSCRIPTIONS.AREA_NOT_COVERED"
     And the response property "$.message" contains "Unable to cover the requested area"
 
-  @geofencing_subscriptions_29_create_with_identifier_mismatch
-  Scenario: Create subscription with identifier mismatch
-    Given the request body includes inconsistent identifiers
-    When the HTTP "POST" request is sent
-    Then the response status code is 422
-    And the response property "$.status" is 422
-    And the response property "$.code" is "IDENTIFIER_MISMATCH"
-    And the response property "$.message" contains "Identifiers are not consistent."
+  # @geofencing_subscriptions_29_create_with_identifier_mismatch deprecated
 
   @geofencing_subscriptions_30_create_with_service_not_applicable
   Scenario: Create subscription for a device not supported by the service

--- a/code/Test_definitions/location-retrieval.feature
+++ b/code/Test_definitions/location-retrieval.feature
@@ -156,17 +156,7 @@ Feature: CAMARA Device location retrieval API, vwip - Operation retrieveLocation
     And the response property "$.code" is "IDENTIFIER_NOT_FOUND"
     And the response property "$.message" contains a user friendly text
 
-  @location_retrieval_14_device_identifiers_mismatch
-  Scenario: Device identifiers mismatch
-    # To test this, at least 2 types of identifiers have to be provided, e.g. a phoneNumber and the IP address of a device associated to a different phoneNumber
-    Given that config_var "identifier_types_unsupported" contains at least 2 items
-    And the header "Authorization" is set to a valid access token which does not identify a single device
-    And the request body property "$.device" includes several identifiers, each of them identifying a valid but different device
-    When the HTTP "POST" request is sent
-    Then the response status code is 422
-    And the response property "$.status" is 422
-    And the response property "$.code" is "IDENTIFIER_MISMATCH"
-    And the response property "$.message" contains a user friendly text
+  # @location_retrieval_14_device_identifiers_mismatch deprecated
 
   @location_retrieval_15_unnecessary_device
   Scenario: Device not to be included when it can be deduced from the access token

--- a/code/Test_definitions/location-verification.feature
+++ b/code/Test_definitions/location-verification.feature
@@ -179,20 +179,6 @@ Feature: CAMARA Device location verification API, vwip - Operation verifyLocatio
     And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
     And the response property "$.message" contains a user-friendly text
 
-
-  # Several identifiers provided but they do not identify the same device
-  # This scenario may happen with 2-legged access tokens, which do not identify a device
-  @location_verification_C01.08_device_identifiers_mismatch
-  Scenario: Device identifiers mismatch
-    Given the header "Authorization" is set to a valid access token which does not identify a single device
-    And at least 2 types of device identifiers are supported by the implementation
-    And the request body property "$.device" includes several identifiers, each of them identifying a valid but different device
-    When the request "verifyLocation" is sent
-    Then the response status code is 422
-    And the response property "$.status" is 422
-    And the response property "$.code" is "IDENTIFIER_MISMATCH"
-    And the response property "$.message" contains a user friendly text
-
   # Generic 400 errors
 
   @location_verification_400.1_no_request_body


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature


#### What this PR does / why we need it:

As of latest Commonalities:

* 422 IDENTIIFIERS_MISMATCH error has been deprecated
* New `DeviceResponse` schema introduced which limits maxProperties: 1,  to be uses in responses (and events) back to the client in cases where multiple identifiers were provided

This PR removes the error and adapts requests and responses to the new Device schemas. Descriptions and some documentation is aligned as well.


#### Which issue(s) this PR fixes:

Fixes #347 

#### Special notes for reviewers:

Some of the changes would be potentially updated as well in the Commonalities artifacts 


#### Changelog input

```
 - Error 422 IDENTIFIERS_MISMATCH deprecated
 - Device object in responses is now limited to one identifier (to be chosen by the implementation among the ones provided by the client in cases where several are included in the request)
```
