### PR TITLE
[geofencing-subscriptions]: Define `id` to be mandatory in SubscriptionAsync

### DIFF
--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -659,6 +659,8 @@ components:
     SubscriptionAsync:
       description: Response for an event-type subscription request managed asynchronously (Creation or Deletion).
       type: object
+      required:
+        - id
       properties:
         id:
           $ref: "#/components/schemas/SubscriptionId"


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* enhancement/feature


#### What this PR does / why we need it:
Define `id` to be mandatory in SubscriptionAsync



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #355 


#### Changelog input

```
 release-note
 * Define `id` to be mandatory in SubscriptionAsync
```

