### PR TITLE
Align radius with CAMARA_common.yaml

### DIFF
--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -842,12 +842,11 @@ components:
             center:
               $ref: "#/components/schemas/Point"
             radius:
-              type: integer
+              type: number
               description: |
                 Expected accuracy for the subscription event of device location, in meters from `center`.
                 Note: The area surface could be restricted locally depending on regulations. Implementations may enforce a larger minimum radius (e.g. 1000 meters).
               minimum: 1
-              maximum: 200000
           required:
             - center
             - radius

--- a/code/API_definitions/location-verification.yaml
+++ b/code/API_definitions/location-verification.yaml
@@ -285,12 +285,11 @@ components:
             center:
               $ref: "#/components/schemas/Point"
             radius:
-              type: integer
+              type: number
               description: |
                 Expected accuracy for the verification, in meters from `center`.
                 Note: The area surface could be restricted locally depending on regulations. Implementations may enforce a larger minimum radius (e.g. 1000 meters).
               minimum: 1
-              maximum: 200000
           required:
             - center
             - radius


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

location-verification and geofencing-subscriptions used a schema for `radius` (property of `Area`, `Circle`) that was not aligned with model in CAMARA_common.yaml (already applied to location-retrieval)


#### Which issue(s) this PR fixes:

Fixes #364 

#### Special notes for reviewers:

Descriptions particularized for the APIs have been kept

#### Changelog input

```
radius for Circle defined as `number` without explicit maximum for `Location Verification` and Geofencing Subscriptions

```
