### PR TITLE
Explicit minimum of 0 to maxAge

### DIFF
--- a/code/API_definitions/location-retrieval.yaml
+++ b/code/API_definitions/location-retrieval.yaml
@@ -241,6 +241,7 @@ components:
           $ref: '#/components/schemas/Device'
         maxAge:
           type: integer
+          minimum: 0
           description: Maximum age of the location information which is accepted for the location retrieval (in seconds). Absence of maxAge means "any age" and maxAge=0 means a fresh calculation.
         maxSurface:
           type: integer

--- a/code/API_definitions/location-verification.yaml
+++ b/code/API_definitions/location-verification.yaml
@@ -450,6 +450,7 @@ components:
     MaxAge:
       description: The maximum age (in seconds) for the location known by the implementation, which is accepted for the verification. Absence of maxAge means "any age" and maxAge=0 means a fresh calculation.
       type: integer
+      minimum: 0
       example: 120
 
     VerificationResult:


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

Sets an explicit minimum of 0 to maxAge

#### Which issue(s) this PR fixes:

Fixes #385 

#### Special notes for reviewers:



#### Changelog input

```
Added `minimum: 0` for `maxAge` in location-verification and location-retrieval

```

