### PR TITLE
fix: declare CloudEvent schema type

### DIFF
--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -861,6 +861,7 @@ components:
 
     CloudEvent:
       description: The notification callback.
+      type: object
       required:
         - id
         - source


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* correction



#### What this PR does / why we need it:

Adds the missing type: object declaration to the CloudEvent schema in geofencing-subscriptions.yaml.

This resolves the CAMARA Validation S-016 error reported on PR [https://github.com/camaraproject/DeviceRoamingStatus/pull/75: components.schemas.CloudEvent must declare a type or combiner](https://github.com/camaraproject/DeviceLocation/pull/403)


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:



#### Changelog input

```
 release-note
Fix CloudEvent schema type declaration in geofencing-subscriptions

```

#### Additional documentation 

This section can be blank.



```
docs

```
