### PR TITLE
test: align DeviceLocation test plans with specs and r4.3 artifacts

### DIFF
--- a/code/Test_definitions/geofencing-subscriptions.feature
+++ b/code/Test_definitions/geofencing-subscriptions.feature
@@ -50,7 +50,7 @@ Feature: Camara Geofencing Subscriptions API, vwip - Operations on subscriptions
     And event notification "subscription-started" is received on callback-url
     And notification body complies with the OAS schema at "#/components/schemas/EventSubscriptionStarted"
     And type="org.camaraproject.geofencing-subscriptions.v0.subscription-started"
-    And the response property "$.initiationReason" is "SUBSCRIPTION_CREATED"
+    And the response property "$.data.initiationReason" is "SUBSCRIPTION_CREATED"
 
   @geofencing_subscriptions_04_Operation_to_retrieve_list_of_subscriptions_when_no_records
   Scenario: Get a list of Geofencing subscriptions when no subscriptions available
@@ -95,7 +95,7 @@ Feature: Camara Geofencing Subscriptions API, vwip - Operations on subscriptions
     Then the event notification "subscription-ended" is received on callback-url
     And notification body complies with the OAS schema at "#/components/schemas/EventSubscriptionEnded"
     And type="org.camaraproject.geofencing-subscriptions.v0.subscription-ended"
-    And the response property "$.terminationReason" is "SUBSCRIPTION_EXPIRED"
+    And the response property "$.data.terminationReason" is "SUBSCRIPTION_EXPIRED"
 
   @geofencing_subscriptions_09_subscription_ends_on_max_events
   Scenario: Receive notification for subscription-ended event on max events reached
@@ -105,7 +105,7 @@ Feature: Camara Geofencing Subscriptions API, vwip - Operations on subscriptions
     And event notification "subscription-ended" is received on callback-url
     And notification body complies with the OAS schema at "#/components/schemas/EventSubscriptionEnded"
     And type="org.camaraproject.geofencing-subscriptions.v0.subscription-ended"
-    And the response property "$.terminationReason" is "MAX_EVENTS_REACHED"
+    And the response property "$.data.terminationReason" is "MAX_EVENTS_REACHED"
 
   @geofencing_subscriptions_10_subscription_delete_event_validation
   Scenario: Receive notification for subscription-ended event on deletion
@@ -115,7 +115,17 @@ Feature: Camara Geofencing Subscriptions API, vwip - Operations on subscriptions
     And event notification "subscription-ended" is received on callback-url
     And notification body complies with the OAS schema at "#/components/schemas/EventSubscriptionEnded"
     And type="org.camaraproject.geofencing-subscriptions.v0.subscription-ended"
-    And the response property "$.terminationReason" is "SUBSCRIPTION_DELETED"
+    And the response property "$.data.terminationReason" is "SUBSCRIPTION_DELETED"
+
+  @geofencing_subscriptions_subscription_ends_on_access_token_expired
+  Scenario: Receive notification for subscription-ended event on access token expiry
+    Given an existing Geofencing subscription created with a "$.sinkCredential.credentialType" set to "ACCESSTOKEN"
+    And the sinkCredential access token has an expiration time in the near future
+    When the sinkCredential access token expires
+    Then the event notification "subscription-ended" is received on callback-url
+    And notification body complies with the OAS schema at "#/components/schemas/EventSubscriptionEnded"
+    And type="org.camaraproject.geofencing-subscriptions.v0.subscription-ended"
+    And the response property "$.data.terminationReason" is "ACCESS_TOKEN_EXPIRED"
 
   @geofencing_subscriptions_11_receive_notification_when_device_enters_geofence
   Scenario: Receive notification for area-entered event
@@ -146,6 +156,15 @@ Feature: Camara Geofencing Subscriptions API, vwip - Operations on subscriptions
     Then the response code is 201 or 202
     And an event notification of the subscribed type is received on callback-url
     And notification body complies with the OAS schema at "#/components/schemas/CloudEvent"
+
+  @geofencing_subscriptions_receive_notification_when_subscription_is_updated
+  Scenario: Receive notification for subscription-updated event
+    Given an existing Geofencing subscription that the server updates (e.g. area adjustment due to system constraints)
+    When the subscription is updated by the server
+    Then the event notification "subscription-updated" is received on callback-url
+    And notification body complies with the OAS schema at "#/components/schemas/EventSubscriptionUpdated"
+    And type="org.camaraproject.geofencing-subscriptions.v0.subscription-updated"
+    And the notification property "$.data.subscriptionId" is equal to the existing subscriptionId
 
   # Error scenarios for management of input parameter device
 
@@ -306,42 +325,13 @@ Feature: Camara Geofencing Subscriptions API, vwip - Operations on subscriptions
     And the response property "$.message" contains a user friendly text
 
   @geofencing_subscriptions_400.7_invalid_url
-  Scenario: Subscription creation with sink
+  Scenario: Subscription creation with invalid sink URL
     Given a valid subscription request body
-    When the request "createGeofencingSubscription" is sent
     And the request property "$.sink" is not matching the defined pattern
-    Then the response property "$.status" is 400
+    When the request "createGeofencingSubscription" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_SINK"
-    And the response property "$.message" contains a user friendly text
-
-  @geofencing_subscriptions_400.8_no_authorization_header_for_create_subscription
-  Scenario: No Authorization header for create subscription
-    Given a valid geofencing subscription request body
-    And the request does not include the "Authorization" header
-    When the request "createGeofencingSubscription" is sent
-    Then the response status code is 401
-    And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
-    And the response property "$.message" contains a user friendly text
-
-  @geofencing_subscriptions_400.9_expired_access_token_for_create_subscription
-  Scenario: Expired access token for create subscription
-    Given a valid geofencing subscription request body and header "Authorization" is expired
-    When the request "createGeofencingSubscription" is sent
-    Then the response status code is 401
-    And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
-    And the response property "$.message" contains a user friendly text
-
-  @geofencing_subscriptions_400.10_invalid_access_token_for_create_subscription
-  Scenario: Invalid access token for create subscription
-    Given a valid geofencing subscription request body
-    And header "Authorization" set to an invalid access token
-    When the request "createGeofencingSubscription" is sent
-    Then the response status code is 401
-    And the response header "Content-Type" is "application/json"
-    And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   # Error code 401
@@ -422,7 +412,7 @@ Feature: Camara Geofencing Subscriptions API, vwip - Operations on subscriptions
 
   @geofencing_subscriptions_422.1_create_with_an_unsupported_area
   Scenario: Create subscription with an unsupported area
-    Given the request body property "$.area" is set to an unsupported / uncovered area
+    Given the request body property "$.config.subscriptionDetail.area" is set to an unsupported / uncovered area
     When the request "createGeofencingSubscription" is sent
     Then the response status code is 422
     And the response property "$.status" is 422
@@ -431,7 +421,7 @@ Feature: Camara Geofencing Subscriptions API, vwip - Operations on subscriptions
 
   @geofencing_subscriptions_422.2_create_with_an_invalid_area
   Scenario: Create subscription with an invalid area
-    Given the request body property "$.area" is set with an too small area-size
+    Given the request body property "$.config.subscriptionDetail.area" is set with an too small area-size
     When the request "createGeofencingSubscription" is sent
     Then the response status code is 422
     And the response property "$.status" is 422

--- a/code/Test_definitions/geofencing-subscriptions.feature
+++ b/code/Test_definitions/geofencing-subscriptions.feature
@@ -166,6 +166,41 @@ Feature: Camara Geofencing Subscriptions API, vwip - Operations on subscriptions
     And type="org.camaraproject.geofencing-subscriptions.v0.subscription-updated"
     And the notification property "$.data.subscriptionId" is equal to the existing subscriptionId
 
+  @geofencing_subscriptions_creation_with_accesstoken_sink_credential
+  Scenario: Create subscription with ACCESSTOKEN sink credential
+    Given a valid subscription request body
+    And the request body property "$.sinkCredential.credentialType" is set to "ACCESSTOKEN"
+    And the request body property "$.sinkCredential.accessTokenType" is set to "bearer"
+    And the request body property "$.sinkCredential.accessToken" is set to a valid token value
+    When the request "createGeofencingSubscription" is sent
+    Then the response code is 201 or 202
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "#/components/schemas/Subscription"
+
+  @geofencing_subscriptions_creation_with_private_key_jwt_out_of_band
+  Scenario: Create subscription with PRIVATE_KEY_JWT sink credential (pre-provisioned out of band)
+    Given the PRIVATE_KEY_JWT mechanism has been pre-configured out-of-band for this implementation
+    And a valid subscription request body
+    And the request body property "$.sinkCredential.credentialType" is set to "PRIVATE_KEY_JWT"
+    When the request "createGeofencingSubscription" is sent
+    Then the response code is 201 or 202
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "#/components/schemas/Subscription"
+
+  @geofencing_subscriptions_creation_with_private_key_jwt_in_band
+  Scenario: Create subscription with PRIVATE_KEY_JWT sink credential (in-band provisioning)
+    Given the PRIVATE_KEY_JWT mechanism supports in-band key provisioning for this implementation
+    And a valid subscription request body
+    And the request body property "$.sinkCredential.credentialType" is set to "PRIVATE_KEY_JWT"
+    And the request body includes the public key for notification verification
+    When the request "createGeofencingSubscription" is sent
+    Then the response code is 201 or 202
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "#/components/schemas/Subscription"
+
   # Error scenarios for management of input parameter device
 
   @geofencing_subscriptions_C01.01_device_empty
@@ -334,6 +369,16 @@ Feature: Camara Geofencing Subscriptions API, vwip - Operations on subscriptions
     And the response property "$.code" is "INVALID_SINK"
     And the response property "$.message" contains a user friendly text
 
+  @geofencing_subscriptions_400.8_invalid_x-correlator
+  Scenario: Invalid x-correlator value
+    Given a valid geofencing subscription request body
+    And the header "x-correlator" does not comply with the OAS schema at "/components/schemas/XCorrelator"
+    When the request "createGeofencingSubscription" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
+
   # Error code 401
 
   @geofencing_subscriptions_creation_401.1_no_authorization_header
@@ -387,6 +432,96 @@ Feature: Camara Geofencing Subscriptions API, vwip - Operations on subscriptions
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
     And the response property "$.message" contains a user friendly text
+
+  @geofencing_subscriptions_401_expired_access_token_for_retrieve_subscription
+  Scenario: Expired access token for retrieve subscription
+    Given the header "Authorization" is set to an expired access token
+    And the path parameter "subscriptionId" is set to an existing subscription identifier
+    When the request "retrieveGeofencingSubscription" is sent
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.message" contains a user friendly text
+
+  @geofencing_subscriptions_401_invalid_access_token_for_retrieve_subscription
+  Scenario: Invalid access token for retrieve subscription
+    Given the header "Authorization" is set to an invalid access token
+    And the path parameter "subscriptionId" is set to an existing subscription identifier
+    When the request "retrieveGeofencingSubscription" is sent
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.message" contains a user friendly text
+
+  @geofencing_subscriptions_401_no_authorization_header_for_list_subscriptions
+  Scenario: No Authorization header for list subscriptions
+    Given the header "Authorization" is removed
+    When the request "retrieveGeofencingSubscriptionList" is sent
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.message" contains a user friendly text
+
+  @geofencing_subscriptions_401_expired_access_token_for_list_subscriptions
+  Scenario: Expired access token for list subscriptions
+    Given the header "Authorization" is set to an expired access token
+    When the request "retrieveGeofencingSubscriptionList" is sent
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.message" contains a user friendly text
+
+  @geofencing_subscriptions_401_invalid_access_token_for_list_subscriptions
+  Scenario: Invalid access token for list subscriptions
+    Given the header "Authorization" is set to an invalid access token
+    When the request "retrieveGeofencingSubscriptionList" is sent
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.message" contains a user friendly text
+
+  @geofencing_subscriptions_401_expired_access_token_for_delete_subscription
+  Scenario: Expired access token for delete subscription
+    Given the header "Authorization" is set to an expired access token
+    And the path parameter "subscriptionId" is set to an existing subscription identifier
+    When the request "deleteGeofencingSubscription" is sent
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.message" contains a user friendly text
+
+  @geofencing_subscriptions_401_invalid_access_token_for_delete_subscription
+  Scenario: Invalid access token for delete subscription
+    Given the header "Authorization" is set to an invalid access token
+    And the path parameter "subscriptionId" is set to an existing subscription identifier
+    When the request "deleteGeofencingSubscription" is sent
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.message" contains a user friendly text
+
+  # Error code 403
+
+  @geofencing_subscriptions_403_subscription_mismatch
+  Scenario Outline: Access to subscription belonging to a different API client
+    Given the path parameter "subscriptionId" is set to an identifier of a valid subscription belonging to a different API client
+    When the request "<operation>" is sent
+    Then the response status code is 403
+    And the response property "$.status" is 403
+    And the response property "$.code" is "SUBSCRIPTION_MISMATCH"
+    And the response property "$.message" contains a user friendly text
+
+    Examples:
+      | operation                      |
+      | retrieveGeofencingSubscription |
+      | deleteGeofencingSubscription   |
 
   # Error code 404
 

--- a/code/Test_definitions/location-retrieval.feature
+++ b/code/Test_definitions/location-retrieval.feature
@@ -49,6 +49,19 @@ Feature: CAMARA Device location retrieval API, vwip - Operation retrieveLocation
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/Location"
 
+  @location_retrieval_200.3_location_retrieval_returns_polygon
+  Scenario: Retrieve location of a device returned as a polygon area
+    # This scenario applies only to implementations that can return a POLYGON area type
+    Given that the implementation is able to return a location of type POLYGON
+    And a valid testing device supported by the service for which the implementation returns a polygon area, identified by the token or provided in the request body
+    When the request "retrieveLocation" is sent
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "#/components/schemas/Location"
+    And the response property "$.area.areaType" is "POLYGON"
+    And the response property "$.area.boundary" is a non-empty array
+
   @location_retrieval_200.2_location_retrieval_for_device_with_maxAge
   Scenario: Retrieve location of a device specifying maxAge
     # maxAge could be tested with several values with scenario variable
@@ -137,7 +150,6 @@ Feature: CAMARA Device location retrieval API, vwip - Operation retrieveLocation
   Scenario: Service not available for the device
     Given that the service is not available for all devices commercialized by the API provider
     And a valid device, identified by the token or provided in the request body, for which the service is not applicable
-    And a valid device, provided in the request body, for which the service is not applicable
     When the request "retrieveLocation" is sent
     Then the response status code is 422
     And the response property "$.status" is 422
@@ -168,15 +180,19 @@ Feature: CAMARA Device location retrieval API, vwip - Operation retrieveLocation
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @location_retrieval_400.2_max_age_schema_compliant
-  Scenario: Input property values doe not comply with the schema
-    Given a valid testing device supported by the service, identified by the token or provided in the request body
-    And the "maxAge" is set to 6a0
+  @location_retrieval_400.2_other_input_properties_schema_not_compliant
+  Scenario Outline: Input property values do not comply with the schema
+    Given the request body property "<input_property>" does not comply with the OAS schema at <oas_spec_schema>
     When the request "retrieveLocation" is sent
     Then the response status code is 400
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
+
+    Examples:
+      | input_property | oas_spec_schema                                                               |
+      | $.maxAge       | /components/schemas/RetrievalLocationRequest/properties/maxAge               |
+      | $.maxSurface   | /components/schemas/RetrievalLocationRequest/properties/maxSurface           |
 
   # Error code 401
 

--- a/code/Test_definitions/location-retrieval.feature
+++ b/code/Test_definitions/location-retrieval.feature
@@ -194,6 +194,15 @@ Feature: CAMARA Device location retrieval API, vwip - Operation retrieveLocation
       | $.maxAge       | /components/schemas/RetrievalLocationRequest/properties/maxAge               |
       | $.maxSurface   | /components/schemas/RetrievalLocationRequest/properties/maxSurface           |
 
+  @location_retrieval_400.3_invalid_x-correlator
+  Scenario: Invalid x-correlator value
+    Given the header "x-correlator" does not comply with the OAS schema at "/components/schemas/XCorrelator"
+    When the request "retrieveLocation" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
+
   # Error code 401
 
   @location_retrieval_401.1_no_authorization_header

--- a/code/Test_definitions/location-verification.feature
+++ b/code/Test_definitions/location-verification.feature
@@ -80,6 +80,21 @@ Feature: CAMARA Device location verification API, vwip - Operation verifyLocatio
     And the response property "$.lastLocationTime" exists
     And the response property "$.matchRate" does not exist
 
+  @location_verification_05_device_echoed_in_response_for_2legged_token
+  Scenario: Device identifier echoed in response when using 2-legged access token with multiple identifiers
+    # When a 2-legged access token is used and the request contains multiple device identifiers,
+    # the server must return the device identifier it used for the location check
+    Given the header "Authorization" is set to a valid 2-legged access token which does not identify a single device
+    And the request body property "$.device" includes multiple valid device identifiers
+    And the request body property "$.area" is set to a valid area covered by the service
+    When the request "verifyLocation" is sent
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "/components/schemas/VerifyLocationResponse"
+    And the response property "$.device" exists
+    And the response property "$.device" complies with the OAS schema at "/components/schemas/DeviceResponse"
+
   # Error scenarios for management of input parameter device
 
   @location_verification_C01.01_device_empty
@@ -184,7 +199,7 @@ Feature: CAMARA Device location verification API, vwip - Operation verifyLocatio
 
   @location_verification_400.3_other_input_properties_schema_not_compliant
   # Test other input properties in addition to device
-  Scenario Outline: Input property values doe not comply with the schema
+  Scenario Outline: Input property values do not comply with the schema
     Given the request body property "<input_property>" does not comply with the OAS schema at <oas_spec_schema>
     When the request "verifyLocation" is sent
     Then the response status code is 400

--- a/code/Test_definitions/location-verification.feature
+++ b/code/Test_definitions/location-verification.feature
@@ -135,7 +135,7 @@ Feature: CAMARA Device location verification API, vwip - Operation verifyLocatio
     And the response property "$.code" is "IDENTIFIER_NOT_FOUND"
     And the response property "$.message" contains a user friendly text
 
-  @location_verification_C02.04_unnecessary_device
+  @location_verification_C01.04_unnecessary_device
   Scenario: Device not to be included when it can be deduced from the access token
     Given the header "Authorization" is set to a valid access token identifying a device
     And the request body property "$.device" is set to a valid device
@@ -232,6 +232,15 @@ Feature: CAMARA Device location verification API, vwip - Operation verifyLocatio
       | $.area.center.latitude  |
       | $.area.center.longitude |
       | $.area.radius           |
+
+  @location_verification_400.5_invalid_x-correlator
+  Scenario: Invalid x-correlator value
+    Given the header "x-correlator" does not comply with the OAS schema at "/components/schemas/XCorrelator"
+    When the request "verifyLocation" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
 
   # Error code 401
 


### PR DESCRIPTION
#### What type of PR is this?

tests

#### What this PR does / why we need it:

Aligns the three Gherkin test plans with the OpenAPI specs updated for Spring26 (Commonalities 0.8.0) and with the CAMARA r4.3 testing artifacts (`Commonalities/artifacts/testing/`).

**geofencing-subscriptions:**
- Corrected JSONPaths: `$.config.subscriptionDetail.area` for area parameters; `$.data.terminationReason` and `$.data.initiationReason` for CloudEvent notification fields.
- Fixed step ordering in scenario 400.7; removed misclassified 401 scenarios previously tagged as 400.x.
- Added `ACCESS_TOKEN_EXPIRED` termination-reason scenario and subscription-updated notification scenario.
- Added sink-credential creation scenarios (ACCESSTOKEN, PRIVATE_KEY_JWT out-of-band, PRIVATE_KEY_JWT in-band).
- Added per-operation 401 auth-error scenarios for GET by ID, LIST, and DELETE.
- Added new 403 section with `SUBSCRIPTION_MISMATCH` Scenario Outline covering GET and DELETE by ID.
- Added `400.8_invalid_x-correlator` scenario.

**location-retrieval:**
- Removed duplicate `Given` step in C01.07.
- Rewrote scenario 400.2 as a Scenario Outline with correct OAS schema paths.
- Added POLYGON area-type scenario.
- Added `400.3_invalid_x-correlator` scenario.

**location-verification:**
- Fixed typo in scenario 400.3.
- Added device-echoed-in-response scenario for 2-legged access tokens.
- Renamed `C02.04` tag to `C01.04` (correct C01 template prefix).
- Added `400.5_invalid_x-correlator` scenario.

#### Which issue(s) this PR fixes:

Fixes #413

#### Special notes for reviewers:

The `event-subscription-template.feature` in Commonalities r4.3 asserts `$.terminationReason` and `$.initiationReason` at the CloudEvent root. This is incorrect: `CAMARA_event_common.yaml` defines `data` as a nested object on the CloudEvent envelope, so the correct paths are `$.data.terminationReason` and `$.data.initiationReason`. This PR intentionally keeps those corrected paths.

Template scenarios 15–16 (sinkCredential echoed in GET subscription response) are not applicable — the geofencing `Subscription` response schema does not include `sinkCredential`. Template pagination scenarios 70–75 are not applicable — `GET /subscriptions` has no `page`/`perPage` query parameters in the spec.

#### Changelog input

```
release-note
* Aligned test plans for all three DeviceLocation APIs with updated OpenAPI specs (Commonalities 0.8.0) and CAMARA r4.3 testing artifacts
```

#### Additional documentation

This section can be blank.