### PR TITLE
fix(geofencing-subscriptions): resolve S-015 and S-211 validation warnings

### DIFF
--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -187,7 +187,7 @@ paths:
                 content:
                   application/cloudevents+json:
                     schema:
-                      $ref: "#/components/schemas/CloudEvent"
+                      $ref: "#/components/schemas/GeofencingNotificationEvent"
                     examples:
                       CIRCLE_AREA_ENTERED:
                         $ref: "#/components/examples/CIRCLE_AREA_ENTERED"
@@ -374,8 +374,6 @@ components:
       schema:
         $ref: '../common/CAMARA_common.yaml#/components/schemas/XCorrelator'
   schemas:
-    XCorrelator:
-      $ref: '../common/CAMARA_common.yaml#/components/schemas/XCorrelator'
     ErrorInfo:
       $ref: '../common/CAMARA_common.yaml#/components/schemas/ErrorInfo'
 
@@ -509,7 +507,7 @@ components:
         - org.camaraproject.geofencing-subscriptions.v0.area-entered
         - org.camaraproject.geofencing-subscriptions.v0.area-left
 
-    NotificationEventType:
+    GeofencingEventType:
       type: string
       description: |
         area-entered - Event triggered when the device enters the given area
@@ -681,20 +679,14 @@ components:
     Point:
       $ref: '../common/CAMARA_common.yaml#/components/schemas/Point'
 
-    Latitude:
-      $ref: '../common/CAMARA_common.yaml#/components/schemas/Latitude'
-
-    Longitude:
-      $ref: '../common/CAMARA_common.yaml#/components/schemas/Longitude'
-
-    CloudEvent:
+    GeofencingNotificationEvent:
       description: The notification callback.
       allOf:
         - $ref: '../common/CAMARA_event_common.yaml#/components/schemas/CloudEvent'
         - type: object
           properties:
             type:
-              $ref: "#/components/schemas/NotificationEventType"
+              $ref: "#/components/schemas/GeofencingEventType"
       discriminator:
         propertyName: "type"
         mapping:
@@ -704,23 +696,11 @@ components:
           org.camaraproject.geofencing-subscriptions.v0.subscription-updated: "#/components/schemas/EventSubscriptionUpdated"
           org.camaraproject.geofencing-subscriptions.v0.subscription-ended: "#/components/schemas/EventSubscriptionEnded"
 
-    Source:
-      $ref: '../common/CAMARA_event_common.yaml#/components/schemas/Source'
-
-    DateTime:
-      $ref: '../common/CAMARA_common.yaml#/components/schemas/DateTime'
-
     SubscriptionId:
       $ref: '../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionId'
 
     SinkCredential:
       $ref: '../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential'
-
-    AccessTokenCredential:
-      $ref: '../common/CAMARA_event_common.yaml#/components/schemas/AccessTokenCredential'
-
-    PrivateKeyJWTCredential:
-      $ref: '../common/CAMARA_event_common.yaml#/components/schemas/PrivateKeyJWTCredential'
 
     HTTPSettings:
       $ref: '../common/CAMARA_event_common.yaml#/components/schemas/HTTPSettings'
@@ -734,7 +714,7 @@ components:
     EventAreaLeft:
       description: Event structure for event when the device leaves the area.
       allOf:
-        - $ref: "#/components/schemas/CloudEvent"
+        - $ref: "#/components/schemas/GeofencingNotificationEvent"
         - type: object
           properties:
             data:
@@ -743,7 +723,7 @@ components:
     EventAreaEntered:
       description: Event structure for event when the device enters the area.
       allOf:
-        - $ref: "#/components/schemas/CloudEvent"
+        - $ref: "#/components/schemas/GeofencingNotificationEvent"
         - type: object
           properties:
             data:
@@ -752,7 +732,7 @@ components:
     EventSubscriptionStarted:
       description: Event structure for event subscription started
       allOf:
-        - $ref: "#/components/schemas/CloudEvent"
+        - $ref: "#/components/schemas/GeofencingNotificationEvent"
         - type: object
           properties:
             data:
@@ -782,7 +762,7 @@ components:
     EventSubscriptionUpdated:
       description: Event structure for event subscription updated
       allOf:
-        - $ref: "#/components/schemas/CloudEvent"
+        - $ref: "#/components/schemas/GeofencingNotificationEvent"
         - type: object
           properties:
             data:
@@ -812,7 +792,7 @@ components:
     EventSubscriptionEnded:
       description: Event structure for event subscription ends.
       allOf:
-        - $ref: "#/components/schemas/CloudEvent"
+        - $ref: "#/components/schemas/GeofencingNotificationEvent"
         - type: object
           properties:
             data:

--- a/code/Test_definitions/geofencing-subscriptions.feature
+++ b/code/Test_definitions/geofencing-subscriptions.feature
@@ -155,7 +155,7 @@ Feature: Camara Geofencing Subscriptions API, vwip - Operations on subscriptions
     When the request "createGeofencingSubscription" is sent
     Then the response code is 201 or 202
     And an event notification of the subscribed type is received on callback-url
-    And notification body complies with the OAS schema at "#/components/schemas/CloudEvent"
+    And notification body complies with the OAS schema at "#/components/schemas/GeofencingNotificationEvent"
 
   @geofencing_subscriptions_receive_notification_when_subscription_is_updated
   Scenario: Receive notification for subscription-updated event


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Resolves the S-015 and S-211 validation warnings surfaced by the CAMARA linter in PR #415 (Release Review r4.1 rc).

**S-015 (PascalCase schema name):** The local schema named `CloudEvent` in `geofencing-subscriptions.yaml` collided with the `CloudEvent` base schema from `CAMARA_event_common.yaml`. When bundled, the local schema was renamed to `CloudEvent-2`, failing the PascalCase rule. The fix renames the local envelope schema to `GeofencingNotificationEvent` and the associated event-type enum from `NotificationEventType` to `GeofencingEventType`, following the same pattern applied in QoSBooking and QosProvisioning.

**S-211 (unused components):** Seven passthrough schema re-exports (`XCorrelator`, `Latitude`, `Longitude`, `Source`, `DateTime`, `AccessTokenCredential`, `PrivateKeyJWTCredential`) were defined in `components/schemas` but never referenced locally. They have been removed.

**S-313 hints and G-004 warning** are dismissed and documented in issue #416: the string-format hints are acceptable for free-form fields per the CAMARA linter FAQ; the scenario count (53 vs max 50) reflects the r4.3 test-plan alignment from PR #414 and is deferred to a future revision.

#### Which issue(s) this PR fixes:

Fixes #416

#### Special notes for reviewers:

The external `$ref` to `CAMARA_event_common.yaml#/components/schemas/CloudEvent` inside `GeofencingNotificationEvent` is intentionally unchanged — it refers to the shared CloudEvents 1.0 base schema.

#### Changelog input

```
release-note
* **geofencing-subscriptions:** renamed local notification envelope schema from `CloudEvent` to `GeofencingNotificationEvent` and event-type enum from `NotificationEventType` to `GeofencingEventType` to eliminate bundler name collision (S-015 fix)
* **geofencing-subscriptions:** removed unused passthrough schema re-exports (`XCorrelator`, `Latitude`, `Longitude`, `Source`, `DateTime`, `AccessTokenCredential`, `PrivateKeyJWTCredential`) (S-211 fix)
```

#### Additional documentation

```
docs
```