### PR TITLE
fix(geofencing-subscriptions): resolve remaining S-015 and S-211 warnings

### DIFF
--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -244,7 +244,7 @@ paths:
         "401":
           $ref: "#/components/responses/Generic401"
         "403":
-          $ref: "#/components/responses/Generic403"
+          $ref: "#/components/responses/SubscriptionPermissionDenied403"
         "422":
           $ref: "#/components/responses/CreateSubscriptionUnprocessableEntity422"
         "429":
@@ -279,7 +279,7 @@ paths:
         "401":
           $ref: "#/components/responses/Generic401"
         "403":
-          $ref: "#/components/responses/Generic403"
+          $ref: "#/components/responses/SubscriptionPermissionDenied403"
   /subscriptions/{subscriptionId}:
     get:
       tags:
@@ -308,7 +308,7 @@ paths:
         "401":
           $ref: "#/components/responses/Generic401"
         "403":
-          $ref: "#/components/responses/Generic403"
+          $ref: "#/components/responses/SubscriptionPermissionDenied403"
         "404":
           $ref: "#/components/responses/Generic404"
     delete:
@@ -343,7 +343,7 @@ paths:
         "401":
           $ref: "#/components/responses/Generic401"
         "403":
-          $ref: "#/components/responses/Generic403"
+          $ref: "#/components/responses/SubscriptionPermissionDenied403"
         "404":
           $ref: "#/components/responses/Generic404"
 components:
@@ -615,12 +615,6 @@ components:
 
     NetworkAccessIdentifier:
       $ref: '../common/CAMARA_common.yaml#/components/schemas/NetworkAccessIdentifier'
-
-    DeviceIpv4Addr:
-      $ref: '../common/CAMARA_common.yaml#/components/schemas/DeviceIpv4Address'
-
-    SingleIpv4Addr:
-      $ref: '../common/CAMARA_common.yaml#/components/schemas/SingleIpv4Address'
 
     Port:
       $ref: '../common/CAMARA_common.yaml#/components/schemas/Port'
@@ -975,35 +969,7 @@ components:
     Generic401:
       $ref: '../common/CAMARA_common.yaml#/components/responses/Generic401'
     SubscriptionPermissionDenied403:
-      description: Client does not have sufficient permission.
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 403
-                  code:
-                    enum:
-                      - PERMISSION_DENIED
-                      - SUBSCRIPTION_MISMATCH
-          examples:
-            GENERIC_403_PERMISSION_DENIED:
-              value:
-                status: 403
-                code: PERMISSION_DENIED
-                message: Client does not have sufficient permissions to perform this action.
-            GENERIC_403_TOKEN_MISMATCH:
-              value:
-                status: 403
-                code: SUBSCRIPTION_MISMATCH
-                message: Inconsistent access token for requested events subscription.
+      $ref: '../common/CAMARA_event_common.yaml#/components/responses/SubscriptionPermissionDenied403'
     Generic403:
       description: Client does not have sufficient permission
       headers:

--- a/code/Test_definitions/geofencing-subscriptions.feature
+++ b/code/Test_definitions/geofencing-subscriptions.feature
@@ -226,7 +226,7 @@ Feature: Camara Geofencing Subscriptions API, vwip - Operations on subscriptions
     Examples:
       | device_identifier                                          | oas_spec_schema                             |
       | $.config.subscriptionDetail.device.phoneNumber             | /components/schemas/PhoneNumber             |
-      | $.config.subscriptionDetail.device.ipv4Address             | /components/schemas/DeviceIpv4Addr          |
+      | $.config.subscriptionDetail.device.ipv4Address             | /components/schemas/DeviceIpv4Address        |
       | $.config.subscriptionDetail.device.ipv6Address             | /components/schemas/DeviceIpv6Address       |
       | $.config.subscriptionDetail.device.networkAccessIdentifier | /components/schemas/NetworkAccessIdentifier |
 


### PR DESCRIPTION
#### What type of PR is this?
correction

#### What this PR does / why we need it:

Three unused-component warnings remained in `geofencing-subscriptions.yaml`
after PR #417. This PR resolves all three:

- **`DeviceIpv4Addr`** (schema): passthrough alias with no internal `$ref` usage. Removed; the test-plan schema pin for `ipv4Address` updated from `DeviceIpv4Addr` to the canonical `DeviceIpv4Address` (defined in `CAMARA_common.yaml`).
- **`SingleIpv4Addr`** (schema): fully orphaned passthrough alias. Removed.
- **`SubscriptionPermissionDenied403`** (response): correctly defined with `PERMISSION_DENIED` + `SUBSCRIPTION_MISMATCH` codes but never wired to any endpoint. The inline definition is replaced with a `$ref` to `CAMARA_event_common.yaml` (consistent with how all other common responses are imported), and the response is wired to all four subscription CRUD operations (POST, GET list, GET by ID, DELETE). The callback/notification endpoint retains `Generic403`.

#### Which issue(s) this PR fixes:

Fixes #419

#### Special notes for reviewers:

The wiring of `SubscriptionPermissionDenied403` to the subscription endpoints is a documentation-only change: it adds `SUBSCRIPTION_MISMATCH` to the set of 403 codes documented on those operations.

#### Changelog input

```
fix(geofencing-subscriptions): remove unused schema aliases (DeviceIpv4Addr, SingleIpv4Addr) and replace inline SubscriptionPermissionDenied403 with a ref to CAMARA_event_common.yaml; wire it to subscription CRUD endpoints
```

#### Additional documentation

This section can be blank.

```
docs

```