### PR TITLE
Correct externalDocs.description wording across all APIs

### DIFF
--- a/code/API_definitions/geofencing-subscriptions.yaml
+++ b/code/API_definitions/geofencing-subscriptions.yaml
@@ -132,7 +132,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   x-camara-commonalities: 0.8.0
 externalDocs:
-  description: Project documentation at Camara
+  description: Product documentation at CAMARA
   url: https://github.com/camaraproject/DeviceLocation
 
 servers:

--- a/code/API_definitions/location-retrieval.yaml
+++ b/code/API_definitions/location-retrieval.yaml
@@ -126,7 +126,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   x-camara-commonalities: 0.8.0
 externalDocs:
-  description: Project documentation at Camara
+  description: Product documentation at CAMARA
   url: https://github.com/camaraproject/DeviceLocation
 servers:
   - url: '{apiRoot}/location-retrieval/vwip'

--- a/code/API_definitions/location-verification.yaml
+++ b/code/API_definitions/location-verification.yaml
@@ -110,7 +110,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   x-camara-commonalities: 0.8.0
 externalDocs:
-  description: Project documentation at CAMARA
+  description: Product documentation at CAMARA
   url: https://github.com/camaraproject/DeviceLocation
 servers:
   - url: "{apiRoot}/location-verification/vwip"


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

`externalDocs.description` was wrong in all three API definitions in this repo (Design Guide §5.4, expected "Product documentation at CAMARA"):
- `geofencing-subscriptions.yaml`: "Project documentation at Camara"
- `location-retrieval.yaml`: "Project documentation at Camara"
- `location-verification.yaml`: "Project documentation at CAMARA"

#### Which issue(s) this PR fixes:

None

#### Special notes for reviewers:

Three one-line fixes, no behavior change.

#### Changelog input

```
release-note
Fix externalDocs.description wording across all API definitions.
```

#### Additional documentation

This section can be blank.

```
docs

```
